### PR TITLE
batchGetItem support for SharedTable strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ See `DocGeneratorRunner` for examples of how to configure builders for each of t
 
 ### Methods
 
- * All implementations support the following methods `createTable`, `describeTable`, `deleteTable`, `getItem`, `putItem`, `scan`, and `query`.
- * `batchGetItem` is supported in `MtAmazonDynamoDbByTable`, `MtAmazonDynamoDbLogger`, and `MtAmazonDynamoDbBase` (and, by extension, `MtAmazonDynamoDbByAccount`)—but not in `MtAmazonDynamoDbBySharedTable`.
+ * All implementations support the following methods `createTable`, `describeTable`, `deleteTable`, `getItem`, `batchGetItem`, `putItem`, `scan`, and `query`.
  * The following methods are NOT supported: `updateTable`, `batchWriteItem`, `createBackup`, `deleteBackup`, `listBackups`, `restoreTableFromBackup`, `createGlobalTable`, `updateGlobalTable`, `describeGlobalTable`, `listGlobalTables`, `describeContinuousBackups`, `describeLimits`, `describeTimeToLive`, `updateTimeToLive`, `listTagsOfResource`, `tagResource`, `untagResource`, `getCachedResponseMetadata`, `waiters`.
  * `ScanRequest` and `QueryRequest` calls currently only support EQ conditions.
  * All `SharedTable*` implementations...
@@ -125,7 +124,7 @@ See `DocGeneratorRunner` for examples of how to configure builders for each of t
 - **v0.9.6** Added `listStreams()` support
 - **v0.9.7** Bug fixes
 - **v0.9.8** Replaced `ByIndex` implementation with `SharedTable`
-- **v0.9.9** Support for `batchGetItem` (for all strategies except `MtAmazonDynamoDbBySharedTable`)
+- **v0.9.9** Support for `batchGetItem`
 
 ## Backlog
 

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtAmazonDynamoDbBySharedTable.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtAmazonDynamoDbBySharedTable.java
@@ -145,7 +145,8 @@ public class MtAmazonDynamoDbBySharedTable extends MtAmazonDynamoDbBase {
         // batch get
         final BatchGetItemResult qualifiedBatchGetItemResult = getAmazonDynamoDb()
             .batchGetItem(qualifiedBatchGetItemRequest);
-        Map<String, List<Map<String, AttributeValue>>> qualifiedItemsByTable = qualifiedBatchGetItemResult.getResponses();
+        Map<String, List<Map<String, AttributeValue>>> qualifiedItemsByTable = qualifiedBatchGetItemResult
+                .getResponses();
 
         // map result
         final BatchGetItemResult unqualifiedBatchGetItemResult = qualifiedBatchGetItemResult.clone();

--- a/src/test/java/com/salesforce/dynamodbv2/BatchGetTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/BatchGetTest.java
@@ -10,12 +10,9 @@ import static com.salesforce.dynamodbv2.testsupport.TestSupport.SOME_FIELD_VALUE
 import static com.salesforce.dynamodbv2.testsupport.TestSupport.SOME_OTHER_FIELD_VALUE;
 import static com.salesforce.dynamodbv2.testsupport.TestSupport.buildItemWithValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.google.common.collect.ImmutableSet;
-import com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.MtAmazonDynamoDbBySharedTable;
 import com.salesforce.dynamodbv2.testsupport.ArgumentBuilder.TestArgument;
 import com.salesforce.dynamodbv2.testsupport.DefaultArgumentProvider;
 import com.salesforce.dynamodbv2.testsupport.TestSupport;
@@ -38,38 +35,23 @@ class BatchGetTest {
         testArgument.forEachOrgContext(
             org -> {
                 final List<String> hashKeyValues = Arrays.asList(HASH_KEY_VALUE, HASH_KEY_OTHER_VALUE);
-
-                // batchGetItem is currently unsupported for MtAmazonDynamoDbBySharedTable strategy
-                if (testArgument.getAmazonDynamoDb() instanceof MtAmazonDynamoDbBySharedTable) {
-                    try {
-                        TestSupport.batchGetItem(testArgument.getHashKeyAttrType(),
-                                testArgument.getAmazonDynamoDb(),
-                                TABLE1,
-                                hashKeyValues,
-                                Optional.empty());
-                        fail("Expected UnsupportedOperationException not thrown.");
-                    } catch (UnsupportedOperationException uoe) {
-                        assertNull(uoe.getMessage());
-                    }
-                } else {
-                    final Set<Map<String, AttributeValue>> gottenItems = TestSupport.batchGetItem(
-                            testArgument.getHashKeyAttrType(),
-                            testArgument.getAmazonDynamoDb(),
-                            TABLE1,
-                            hashKeyValues,
-                            Optional.empty());
-                    final Map<String, AttributeValue> expectedItem0 = buildItemWithValues(
-                            testArgument.getHashKeyAttrType(),
-                            hashKeyValues.get(0),
-                            Optional.empty(),
-                            SOME_FIELD_VALUE + TABLE1 + org);
-                    final Map<String, AttributeValue> expectedItem1 = buildItemWithValues(
-                            testArgument.getHashKeyAttrType(),
-                            hashKeyValues.get(1),
-                            Optional.empty(),
-                            SOME_OTHER_FIELD_VALUE + TABLE1 + org);
-                    assertEquals(ImmutableSet.of(expectedItem0, expectedItem1), gottenItems);
-                }
+                final Set<Map<String, AttributeValue>> gottenItems = TestSupport.batchGetItem(
+                        testArgument.getHashKeyAttrType(),
+                        testArgument.getAmazonDynamoDb(),
+                        TABLE1,
+                        hashKeyValues,
+                        Optional.empty());
+                final Map<String, AttributeValue> expectedItem0 = buildItemWithValues(
+                        testArgument.getHashKeyAttrType(),
+                        hashKeyValues.get(0),
+                        Optional.empty(),
+                        SOME_FIELD_VALUE + TABLE1 + org);
+                final Map<String, AttributeValue> expectedItem1 = buildItemWithValues(
+                        testArgument.getHashKeyAttrType(),
+                        hashKeyValues.get(1),
+                        Optional.empty(),
+                        SOME_OTHER_FIELD_VALUE + TABLE1 + org);
+                assertEquals(ImmutableSet.of(expectedItem0, expectedItem1), gottenItems);
             });
     }
 
@@ -81,39 +63,24 @@ class BatchGetTest {
                 final List<String> hashKeyValues = Arrays.asList(HASH_KEY_VALUE, HASH_KEY_VALUE);
                 final Optional<List<String>> rangeKeyValues = Optional
                         .of(Arrays.asList(RANGE_KEY_VALUE, RANGE_KEY_VALUE + "2"));
-
-                // batchGetItem is currently unsupported for MtAmazonDynamoDbBySharedTable strategy
-                if (testArgument.getAmazonDynamoDb() instanceof MtAmazonDynamoDbBySharedTable) {
-                    try {
-                        TestSupport.batchGetItem(testArgument.getHashKeyAttrType(),
-                                testArgument.getAmazonDynamoDb(),
-                                TABLE3,
-                                hashKeyValues,
-                                rangeKeyValues);
-                        fail("Expected UnsupportedOperationException not thrown.");
-                    } catch (UnsupportedOperationException uoe) {
-                        assertNull(uoe.getMessage());
-                    }
-                } else {
-                    final Set<Map<String, AttributeValue>> gottenItems = TestSupport.batchGetItem(
-                            testArgument.getHashKeyAttrType(),
-                            testArgument.getAmazonDynamoDb(),
-                            TABLE3,
-                            hashKeyValues,
-                            rangeKeyValues);
-                    final Map<String, AttributeValue> expectedItem0 = buildItemWithValues(
-                            testArgument.getHashKeyAttrType(),
-                            hashKeyValues.get(0),
-                            rangeKeyValues.map(rkv -> rkv.get(0)),
-                            SOME_FIELD_VALUE + TABLE3 + org);
-                    final Map<String, AttributeValue> expectedItem1 = buildItemWithValues(
-                            testArgument.getHashKeyAttrType(),
-                            hashKeyValues.get(1),
-                            rangeKeyValues.map(rkv -> rkv.get(1)),
-                            SOME_FIELD_VALUE + TABLE3 + org + "2",
-                            Optional.of(INDEX_FIELD_VALUE));
-                    assertEquals(ImmutableSet.of(expectedItem0, expectedItem1), gottenItems);
-                }
+                final Set<Map<String, AttributeValue>> gottenItems = TestSupport.batchGetItem(
+                        testArgument.getHashKeyAttrType(),
+                        testArgument.getAmazonDynamoDb(),
+                        TABLE3,
+                        hashKeyValues,
+                        rangeKeyValues);
+                final Map<String, AttributeValue> expectedItem0 = buildItemWithValues(
+                        testArgument.getHashKeyAttrType(),
+                        hashKeyValues.get(0),
+                        rangeKeyValues.map(rkv -> rkv.get(0)),
+                        SOME_FIELD_VALUE + TABLE3 + org);
+                final Map<String, AttributeValue> expectedItem1 = buildItemWithValues(
+                        testArgument.getHashKeyAttrType(),
+                        hashKeyValues.get(1),
+                        rangeKeyValues.map(rkv -> rkv.get(1)),
+                        SOME_FIELD_VALUE + TABLE3 + org + "2",
+                        Optional.of(INDEX_FIELD_VALUE));
+                assertEquals(ImmutableSet.of(expectedItem0, expectedItem1), gottenItems);
             });
     }
 


### PR DESCRIPTION
This PR is against Jeremy's batch-support branch.  It basically adds batchGetItem support for the 4th of the 4 "strategies"(ByTable, ByAccount, Logger, and now SharedTable).