### PR TITLE
addressed two maven dependency analyze warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.8</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
 
         <!-- test scope -->
         <dependency>
@@ -186,6 +191,7 @@
                         <configuration>
                             <failOnWarning>false</failOnWarning>
                             <ignoredUnusedDeclaredDependencies>ch.qos.logback:logback-classic</ignoredUnusedDeclaredDependencies>
+                            <ignoredUnusedDeclaredDependencies>org.junit.jupiter:junit-jupiter-engine</ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Fixed the following 2 errors ...

[WARNING] Used undeclared dependencies found:
[WARNING]    com.google.code.findbugs:jsr305:jar:3.0.2:compile
[WARNING] Unused declared dependencies found:
[WARNING]    org.junit.jupiter:junit-jupiter-engine:jar:5.3.1:test