### PR TITLE
added logging of virtual->physical table mappings

### DIFF
--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/metadata/DynamoTableDescriptionImpl.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/metadata/DynamoTableDescriptionImpl.java
@@ -185,7 +185,7 @@ public class DynamoTableDescriptionImpl implements DynamoTableDescription {
 
     @Override
     public String toString() {
-        return "DynamoTableDescriptionImpl{"
+        return "{"
             + "tableName='" + tableName + '\''
             + ", attributeDefinitions=" + attributeDefinitions
             + ", primaryKey=" + primaryKey

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/FieldMapping.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/FieldMapping.java
@@ -7,6 +7,8 @@
 
 package com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl;
 
+import static java.lang.String.format;
+
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
 
 /**
@@ -98,6 +100,11 @@ class FieldMapping {
             return name.equals(field.name)
                 && type == field.type;
         }
+
+        @Override
+        public String toString() {
+            return format("{name=%s, type=%s}", name, type);
+        }
     }
 
     @Override
@@ -118,4 +125,11 @@ class FieldMapping {
             && physicalIndexName.equals(that.physicalIndexName)
             && indexType == that.indexType;
     }
+
+    @Override
+    public String toString() {
+        return format("{source=%s, target=%s, virtualIndexName=%s, physicalIndexName=%s, indexType=%s}",
+                      source, target, virtualIndexName, physicalIndexName, indexType);
+    }
+
 }

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/TableMapping.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/TableMapping.java
@@ -13,6 +13,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.salesforce.dynamodbv2.mt.mappers.index.DynamoSecondaryIndex.DynamoSecondaryIndexType.LSI;
 import static com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.FieldMapping.IndexType.SECONDARYINDEX;
 import static com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.FieldMapping.IndexType.TABLE;
+import static java.lang.String.format;
 
 import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException;
 import com.google.common.annotations.VisibleForTesting;
@@ -111,6 +112,15 @@ class TableMapping {
      */
     Map<String, FieldMapping> getAllVirtualToPhysicalFieldMappingsDeduped() {
         return dedupeFieldMappings(virtualToPhysicalMappings);
+    }
+
+    @Override
+    public String toString() {
+        return format("created virtual to physical table mapping: %s -> %s, virtual: %s, physical: %s"
+                      + ", tableFieldMappings: %s, secondaryIndexFieldMappings: %s",
+                      virtualTable.getTableName(), physicalTable.getTableName(),
+                      virtualTable.toString(), physicalTable.toString(),
+                      virtualToPhysicalMappings, secondaryIndexFieldMappings);
     }
 
     /*

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -23,6 +23,11 @@
     -->
     <logger name="com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.MtAmazonDynamoDbBySharedTable" level="error"/>
 
+    <!--
+        Setting to error reduces verbosity during tests.
+    -->
+    <logger name="com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.TableMappingFactory" level="error"/>
+
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
Generate output that looks like the following when the virtual-to-physical table mapping is created ...

web_1           | 17:37:59.419 [http-nio-5000-exec-2] INFO  .d.m.m.s.i.TableMappingFactory - created table mapping created virtual to physical table mapping: Schema -> SHARED.mt_sharedtablestatic_s_nolsi, virtual: {tableName='Schema', attributeDefinitions=[{AttributeName: Namespace,AttributeType: S}], primaryKey={hashKey='Namespace', hashKeyType=S}, gsiMap=[], lsiMap=[]}, physical: {tableName='SHARED.mt_sharedtablestatic_s_nolsi', attributeDefinitions=[{AttributeName: hk,AttributeType: S}, {AttributeName: gsi_s_hk,AttributeType: S}, {AttributeName: gsi_s_s_hk,AttributeType: S}, {AttributeName: gsi_s_s_rk,AttributeType: S}, {AttributeName: gsi_s_n_hk,AttributeType: S}, {AttributeName: gsi_s_n_rk,AttributeType: N}, {AttributeName: gsi_s_b_hk,AttributeType: S}, {AttributeName: gsi_s_b_rk,AttributeType: B}], primaryKey={hashKey='hk', hashKeyType=S}, gsiMap=[{indexName='gsi_s', keySchema='{hashKey='gsi_s_hk', hashKeyType=S}, type=GSI}, {indexName='gsi_s_n', keySchema='{hashKey='gsi_s_n_hk', hashKeyType=S, rangeKey=gsi_s_n_rk, rangeKeyType=N}, type=GSI}, {indexName='gsi_s_s', keySchema='{hashKey='gsi_s_s_hk', hashKeyType=S, rangeKey=gsi_s_s_rk, rangeKeyType=S}, type=GSI}, {indexName='gsi_s_b', keySchema='{hashKey='gsi_s_b_hk', hashKeyType=S, rangeKey=gsi_s_b_rk, rangeKeyType=B}, type=GSI}], lsiMap=[]}, tableFieldMappings: {Namespace=[{source={name=Namespace, type=S}, target={name=hk, type=S}, virtualIndexName=Schema, physicalIndexName=SHARED.mt_sharedtablestatic_s_nolsi, indexType=TABLE}]}, secondaryIndexFieldMappings: {}