### PR TITLE
Fix a misspelling - s/SEPERATOR/SEPARATOR/g

### DIFF
--- a/src/main/java/com/salesforce/dynamodbv2/mt/util/CachingAmazonDynamoDbStreams.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/util/CachingAmazonDynamoDbStreams.java
@@ -7,7 +7,7 @@ import static com.amazonaws.services.dynamodbv2.model.ShardIteratorType.TRIM_HOR
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Iterables.getLast;
-import static com.salesforce.dynamodbv2.mt.util.ShardIterator.ITERATOR_SEPERATOR;
+import static com.salesforce.dynamodbv2.mt.util.ShardIterator.ITERATOR_SEPARATOR;
 import static java.math.BigInteger.ONE;
 import static java.util.stream.Collectors.toList;
 
@@ -368,7 +368,7 @@ public class CachingAmazonDynamoDbStreams extends DelegatingAmazonDynamoDbStream
             String streamArn = iterator.getArn();
 
             String rest = iterator.getRest();
-            int idx = rest.lastIndexOf(ITERATOR_SEPERATOR);
+            int idx = rest.lastIndexOf(ITERATOR_SEPARATOR);
             String dynamoDbIterator;
             if (idx == -1) {
                 dynamoDbIterator = null;
@@ -560,9 +560,9 @@ public class CachingAmazonDynamoDbStreams extends DelegatingAmazonDynamoDbStream
             }
             String rest = compositeStrings.join(fields);
             if (dynamoDbIterator == null) {
-                return streamArn + ITERATOR_SEPERATOR + rest;
+                return streamArn + ITERATOR_SEPARATOR + rest;
             } else {
-                return dynamoDbIterator + ITERATOR_SEPERATOR + rest;
+                return dynamoDbIterator + ITERATOR_SEPARATOR + rest;
             }
         }
 

--- a/src/main/java/com/salesforce/dynamodbv2/mt/util/ShardIterator.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/util/ShardIterator.java
@@ -2,7 +2,6 @@ package com.salesforce.dynamodbv2.mt.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.salesforce.dynamodbv2.mt.mappers.MtAmazonDynamoDbStreamsBase;
 import java.util.Objects;
 
 /**
@@ -11,8 +10,8 @@ import java.util.Objects;
  */
 public class ShardIterator {
 
-    public static final char ITERATOR_SEPERATOR = '|';
-    private static final String LOCAL_DYNAMODB_PREFIX = "000" + ITERATOR_SEPERATOR;
+    public static final char ITERATOR_SEPARATOR = '|';
+    private static final String LOCAL_DYNAMODB_PREFIX = "000" + ITERATOR_SEPARATOR;
 
     /**
      * Parses shard iterator from string representation.
@@ -25,7 +24,7 @@ public class ShardIterator {
         if (local) {
             value = value.substring(LOCAL_DYNAMODB_PREFIX.length());
         }
-        final int idx = value.indexOf(ITERATOR_SEPERATOR);
+        final int idx = value.indexOf(ITERATOR_SEPARATOR);
         final String arn = value.substring(0, idx);
         final String rest = value.substring(idx + 1);
         return new ShardIterator(local, arn, rest);
@@ -63,7 +62,7 @@ public class ShardIterator {
 
     @Override
     public String toString() {
-        String value = arn + ITERATOR_SEPERATOR + rest;
+        String value = arn + ITERATOR_SEPARATOR + rest;
         if (local) {
             value = LOCAL_DYNAMODB_PREFIX + value;
         }


### PR DESCRIPTION
I found a misspelling in the code. 

`ShardIterator.ITERATOR_SEPERATOR` is a public field. If you need a transition period for other projects, I can mark the existing field as `@Deprecated`.