### PR TITLE
Add more fail statement for error cases

### DIFF
--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/DynamoSecondaryIndexMapperByTypeImplTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/DynamoSecondaryIndexMapperByTypeImplTest.java
@@ -57,7 +57,7 @@ class DynamoSecondaryIndexMapperByTypeImplTest {
             GSI)));
         try {
             new DynamoSecondaryIndexMapperByTypeImpl().lookupPhysicalSecondaryIndex(vsi, physicalTable);
-            fail("It was expected that #lookupPhysicalSecondaryIndex throws MappingException");
+            fail("Expected MappingException not thrown");
         } catch (MappingException ignore) {
             // expected
         }

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/DynamoSecondaryIndexMapperByTypeImplTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/DynamoSecondaryIndexMapperByTypeImplTest.java
@@ -11,6 +11,7 @@ import static com.amazonaws.services.dynamodbv2.model.KeyType.HASH;
 import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.N;
 import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
 import static com.salesforce.dynamodbv2.mt.mappers.index.DynamoSecondaryIndex.DynamoSecondaryIndexType.GSI;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -56,6 +57,7 @@ class DynamoSecondaryIndexMapperByTypeImplTest {
             GSI)));
         try {
             new DynamoSecondaryIndexMapperByTypeImpl().lookupPhysicalSecondaryIndex(vsi, physicalTable);
+            fail("It was expected that #lookupPhysicalSecondaryIndex throws MappingException");
         } catch (MappingException ignore) {
             // expected
         }

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/DynamoSecondaryIndexTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/DynamoSecondaryIndexTest.java
@@ -74,7 +74,7 @@ class DynamoSecondaryIndexTest {
                 "index3",
                 ImmutableList.of(new KeySchemaElement().withAttributeName("hk").withKeyType(HASH)),
                 GSI);
-            fail("It was expected that the constructor throws IllegalArgumentException");
+            fail("Expected IllegalArgumentException not thrown");
         } catch (IllegalArgumentException ignore) {
             // expected
         }

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/DynamoSecondaryIndexTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/DynamoSecondaryIndexTest.java
@@ -16,6 +16,7 @@ import static com.salesforce.dynamodbv2.mt.mappers.index.DynamoSecondaryIndex.Dy
 import static java.util.Optional.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
@@ -73,6 +74,7 @@ class DynamoSecondaryIndexTest {
                 "index3",
                 ImmutableList.of(new KeySchemaElement().withAttributeName("hk").withKeyType(HASH)),
                 GSI);
+            fail("It was expected that the constructor throws IllegalArgumentException");
         } catch (IllegalArgumentException ignore) {
             // expected
         }

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/PrimaryKeyMapperByTypeImplTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/PrimaryKeyMapperByTypeImplTest.java
@@ -12,6 +12,7 @@ import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.N;
 import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
 import static com.google.common.collect.ImmutableList.of;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
 import com.salesforce.dynamodbv2.mt.mappers.MappingException;
@@ -110,8 +111,7 @@ class PrimaryKeyMapperByTypeImplTest {
     private static void assertMappingException(TestFunction test) {
         try {
             HasPrimaryKey hasPrimaryKey = test.run();
-            throw new RuntimeException("expected MappingException not encountered, found:"
-                    + hasPrimaryKey.getPrimaryKey());
+            fail("It was expected MappingException not encountered, found:" + hasPrimaryKey.getPrimaryKey());
         } catch (MappingException ignored) { /* expected */ }
     }
 

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/PrimaryKeyMapperByTypeImplTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/index/PrimaryKeyMapperByTypeImplTest.java
@@ -111,7 +111,7 @@ class PrimaryKeyMapperByTypeImplTest {
     private static void assertMappingException(TestFunction test) {
         try {
             HasPrimaryKey hasPrimaryKey = test.run();
-            fail("It was expected MappingException not encountered, found:" + hasPrimaryKey.getPrimaryKey());
+            fail("Expected MappingException not encountered, found:" + hasPrimaryKey.getPrimaryKey());
         } catch (MappingException ignored) { /* expected */ }
     }
 

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/FieldMapperTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/FieldMapperTest.java
@@ -94,7 +94,7 @@ class FieldMapperTest {
         try {
             buildFieldMapper(buildMtContext())
                     .apply(buildFieldMapping(null, TABLE), new AttributeValue().withS(generateValue()));
-            fail("It was expected that #apply method throws NullPointerException");
+            fail("Expected NullPointerException not thrown");
         } catch (NullPointerException e) {
             // expected
             assertEquals("null attribute type", e.getMessage());

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/FieldMapperTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/FieldMapperTest.java
@@ -14,6 +14,7 @@ import static com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.FieldMapping
 import static com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.FieldMapping.IndexType.TABLE;
 import static java.util.UUID.randomUUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
@@ -93,6 +94,7 @@ class FieldMapperTest {
         try {
             buildFieldMapper(buildMtContext())
                     .apply(buildFieldMapping(null, TABLE), new AttributeValue().withS(generateValue()));
+            fail("It was expected that #apply method throws NullPointerException");
         } catch (NullPointerException e) {
             // expected
             assertEquals("null attribute type", e.getMessage());

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/TableMappingTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/TableMappingTest.java
@@ -360,7 +360,7 @@ class TableMappingTest {
     private static void assertException(TestFunction test, String expectedMessagePrefix) {
         try {
             test.run();
-            fail("It was expected exception '" + expectedMessagePrefix + "' not encountered");
+            fail("Expected exception '" + expectedMessagePrefix + "' not encountered");
         } catch (IllegalArgumentException | NullPointerException e) {
             assertTrue(e.getMessage().startsWith(expectedMessagePrefix),
                     "expectedPrefix=" + expectedMessagePrefix + ", actual=" + e.getMessage());

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/TableMappingTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/TableMappingTest.java
@@ -16,6 +16,7 @@ import static com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.FieldMapping
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -40,7 +41,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-
 
 /**
  * TODO: write Javadoc.
@@ -360,7 +360,7 @@ class TableMappingTest {
     private static void assertException(TestFunction test, String expectedMessagePrefix) {
         try {
             test.run();
-            throw new RuntimeException("expected exception '" + expectedMessagePrefix + "' not encountered");
+            fail("It was expected exception '" + expectedMessagePrefix + "' not encountered");
         } catch (IllegalArgumentException | NullPointerException e) {
             assertTrue(e.getMessage().startsWith(expectedMessagePrefix),
                     "expectedPrefix=" + expectedMessagePrefix + ", actual=" + e.getMessage());


### PR DESCRIPTION
A portion of the tests for error cases doesn't have `fail` statements when an excepted exception is not thrown. This pull request improves those tests.