### PR TITLE
Add OpenJDK 11 to TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
-jdk: oraclejdk8
+jdk:
+  - oraclejdk8
+  - openjdk11
 install:
   - make
 before_script:


### PR DESCRIPTION
It's about time to support the latest LTS (Long Term Support) JDK. This pull request enables the matrix builds for JDK 8 and JDK 11.