### PR TITLE
Rename & refactor MtAmazonDynamoDbContextProviderImpl

### DIFF
--- a/src/main/java/com/salesforce/dynamodbv2/mt/context/impl/MtAmazonDynamoDbContextProviderThreadLocalImpl.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/context/impl/MtAmazonDynamoDbContextProviderThreadLocalImpl.java
@@ -16,11 +16,11 @@ import java.util.Map;
  *
  * @author msgroi
  */
-public class MtAmazonDynamoDbContextProviderImpl implements MtAmazonDynamoDbContextProvider {
+public class MtAmazonDynamoDbContextProviderThreadLocalImpl implements MtAmazonDynamoDbContextProvider {
 
     private static final String CONTEXT_KEY = "multitenant-context";
     public static final String BASE_CONTEXT = "";
-    private final ThreadLocal<Object> threadLocal = new ThreadLocal<>();
+    private static final ThreadLocal<Map<String, String>> CONTEXT_MAP_THREAD_LOCAL = new ThreadLocal<>();
 
     @Override
     public void setContext(String tenantId) {
@@ -34,10 +34,10 @@ public class MtAmazonDynamoDbContextProviderImpl implements MtAmazonDynamoDbCont
     }
 
     private Map<String, String> getContextMap() {
-        Map<String, String> context = (Map<String, String>) threadLocal.get();
+        Map<String, String> context = CONTEXT_MAP_THREAD_LOCAL.get();
         if (context == null) {
             context = new HashMap<>();
-            threadLocal.set(context);
+            CONTEXT_MAP_THREAD_LOCAL.set(context);
         }
         return context;
     }

--- a/src/main/java/com/salesforce/dynamodbv2/mt/util/StreamArn.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/util/StreamArn.java
@@ -1,7 +1,7 @@
 package com.salesforce.dynamodbv2.mt.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderImpl.BASE_CONTEXT;
+import static com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderThreadLocalImpl.BASE_CONTEXT;
 
 import com.salesforce.dynamodbv2.mt.mappers.MtAmazonDynamoDb.MtRecord;
 import java.io.UnsupportedEncodingException;

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/MtAmazonDynamoDbChainTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/MtAmazonDynamoDbChainTest.java
@@ -49,7 +49,7 @@ import com.google.common.io.Resources;
 import com.salesforce.dynamodbv2.dynamodblocal.AmazonDynamoDbLocal;
 import com.salesforce.dynamodbv2.mt.admin.AmazonDynamoDbAdminUtils;
 import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
-import com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderImpl;
+import com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderThreadLocalImpl;
 import com.salesforce.dynamodbv2.mt.mappers.sharedtable.SharedTableBuilder;
 import com.salesforce.dynamodbv2.testsupport.ItemBuilder;
 import com.salesforce.dynamodbv2.testsupport.TestAmazonDynamoDbAdminUtils;
@@ -87,7 +87,7 @@ class MtAmazonDynamoDbChainTest {
     @Test
     void test() throws Exception {
         // create context
-        MtAmazonDynamoDbContextProvider mtContext = new MtAmazonDynamoDbContextProviderImpl();
+        MtAmazonDynamoDbContextProvider mtContext = new MtAmazonDynamoDbContextProviderThreadLocalImpl();
 
         // log message aggregator
         LogAggregator logAggregator = new LogAggregator();

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/ConditionMapperTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/ConditionMapperTest.java
@@ -14,7 +14,7 @@ import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
-import com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderImpl;
+import com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderThreadLocalImpl;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.DynamoTableDescription;
 import com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.FieldMapping.Field;
 import com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.QueryAndScanMapper.QueryRequestWrapper;
@@ -60,7 +60,7 @@ class ConditionMapperTest {
     private void executeKeyConditionsTest(KeyConditionTestInvocation testInvocation) {
         final KeyConditionTestInputs inputs = testInvocation.getInputs();
         final KeyConditionTestExpected expected = testInvocation.getExpected();
-        MtAmazonDynamoDbContextProvider mtContext = new MtAmazonDynamoDbContextProviderImpl();
+        MtAmazonDynamoDbContextProvider mtContext = new MtAmazonDynamoDbContextProviderThreadLocalImpl();
         mtContext.setContext(inputs.getOrg());
         DynamoTableDescription virtualTable = mock(DynamoTableDescription.class);
         when(virtualTable.getTableName()).thenReturn(inputs.getVirtualTableName());

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtAmazonDynamoDbStreamsBySharedTableTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtAmazonDynamoDbStreamsBySharedTableTest.java
@@ -1,6 +1,6 @@
 package com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl;
 
-import static com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderImpl.BASE_CONTEXT;
+import static com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderThreadLocalImpl.BASE_CONTEXT;
 import static com.salesforce.dynamodbv2.testsupport.ArgumentBuilder.MT_CONTEXT;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/salesforce/dynamodbv2/mt/repo/MtDynamoDbTableDescriptionRepoTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/repo/MtDynamoDbTableDescriptionRepoTest.java
@@ -10,7 +10,7 @@ import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableRequest;
 import com.salesforce.dynamodbv2.dynamodblocal.AmazonDynamoDbLocal;
 import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
-import com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderImpl;
+import com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderThreadLocalImpl;
 import com.salesforce.dynamodbv2.mt.repo.MtDynamoDbTableDescriptionRepo.MtDynamoDbTableDescriptionRepoBuilder;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +22,7 @@ public class MtDynamoDbTableDescriptionRepoTest {
     @Test
     void testMetadataTableProvisioningThroughputChange() {
         AmazonDynamoDB dynamoDb = AmazonDynamoDbLocal.getAmazonDynamoDbLocal();
-        MtAmazonDynamoDbContextProvider ctx = new MtAmazonDynamoDbContextProviderImpl();
+        MtAmazonDynamoDbContextProvider ctx = new MtAmazonDynamoDbContextProviderThreadLocalImpl();
         String tableName = "MtDynamoDbTableDescriptionRepoTest_testMetadataTableExists_metadata";
 
         MtDynamoDbTableDescriptionRepoBuilder b = MtDynamoDbTableDescriptionRepo.builder()

--- a/src/test/java/com/salesforce/dynamodbv2/testsupport/ArgumentBuilder.java
+++ b/src/test/java/com/salesforce/dynamodbv2/testsupport/ArgumentBuilder.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.salesforce.dynamodbv2.dynamodblocal.AmazonDynamoDbLocal;
 import com.salesforce.dynamodbv2.dynamodblocal.LocalDynamoDbServer;
 import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
-import com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderImpl;
+import com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderThreadLocalImpl;
 import com.salesforce.dynamodbv2.mt.mappers.MtAmazonDynamoDbByAccount;
 import com.salesforce.dynamodbv2.mt.mappers.MtAmazonDynamoDbByAccount.MtAccountMapper;
 import com.salesforce.dynamodbv2.mt.mappers.MtAmazonDynamoDbByTable;
@@ -71,7 +71,8 @@ public class ArgumentBuilder implements Supplier<List<TestArgument>> {
     private static final AtomicInteger ORG_COUNTER = new AtomicInteger();
     public static final int ORGS_PER_TEST = 2;
     private static final boolean LOGGING_ENABLED = false; // log DDL and DML operations
-    public static final MtAmazonDynamoDbContextProvider MT_CONTEXT = new MtAmazonDynamoDbContextProviderImpl();
+    public static final MtAmazonDynamoDbContextProvider MT_CONTEXT =
+            new MtAmazonDynamoDbContextProviderThreadLocalImpl();
 
     private AmazonDynamoDB rootAmazonDynamoDb = ROOT_AMAZON_DYNAMO_DB;
     private static final String HK_TABLE_NAME = "hkTable";

--- a/src/test/java/com/salesforce/dynamodbv2/testsupport/DocGeneratorRunner.java
+++ b/src/test/java/com/salesforce/dynamodbv2/testsupport/DocGeneratorRunner.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.salesforce.dynamodbv2.dynamodblocal.AmazonDynamoDbLocal;
 import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
-import com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderImpl;
+import com.salesforce.dynamodbv2.mt.context.impl.MtAmazonDynamoDbContextProviderThreadLocalImpl;
 import com.salesforce.dynamodbv2.mt.mappers.MtAmazonDynamoDbByAccount;
 import com.salesforce.dynamodbv2.mt.mappers.MtAmazonDynamoDbByAccount.MtAccountCredentialsMapper;
 import com.salesforce.dynamodbv2.mt.mappers.MtAmazonDynamoDbByAccount.MtAccountMapper;
@@ -103,7 +103,8 @@ class DocGeneratorRunner {
     private static final AmazonDynamoDBClientBuilder AMAZON_DYNAMO_DB_CLIENT_BUILDER = AmazonDynamoDBClientBuilder
             .standard()
             .withRegion(Regions.US_EAST_1);
-    private static final MtAmazonDynamoDbContextProvider MT_CONTEXT = new MtAmazonDynamoDbContextProviderImpl();
+    private static final MtAmazonDynamoDbContextProvider MT_CONTEXT =
+            new MtAmazonDynamoDbContextProviderThreadLocalImpl();
     private static final AmazonDynamoDB ROOT_AMAZON_DYNAMO_DB = IS_LOCAL_DYNAMO
         ? AmazonDynamoDbLocal.getAmazonDynamoDbLocal()
         : AMAZON_DYNAMO_DB_CLIENT_BUILDER.build();


### PR DESCRIPTION
This pull request suggests two changes to MtAmazonDynamoDbContextProviderImpl as follows.

## Rename the impl class not to be confusing

The setter method just updates ThreadLocal value. That means that if a user use the context provider in different threads, it doesn't work as expected. The behavior is surprising and not intuitive. Thus, I suggest to rename it to let users easily understand the characteristics from the name.

## Refactor the internal ThreadLocal value

Generally speaking, a ThreadLocal value can be a static field because the value itself is not shared among threads. In my understanding, doing like this is a common practice. Also, I found that we can specify not `Object` but `Map<String, String>` as the generic type because we won't put other type values into it.