### PR TITLE
addressed comments from code-cleanup branch PR

### DIFF
--- a/src/main/java/com/salesforce/dynamodbv2/mt/util/DynamoDbCapacity.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/util/DynamoDbCapacity.java
@@ -28,8 +28,8 @@ public class DynamoDbCapacity {
 
     /**
      * Returns the capacity for a given ProvisionedThroughput type.
-     * @param throughput - ProvisionedThrouhgput instance
-     * @param capacityType - Type of ProvisionedThrouhgput
+     * @param throughput - ProvisionedThroughput instance
+     * @param capacityType - Type of ProvisionedThroughput
      * @return capacity set for given capacityType or default capacity if unset
      */
     public Long getCapacity(ProvisionedThroughput throughput, CapacityType capacityType) {

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/CreateTableRequestBuilderTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/CreateTableRequestBuilderTest.java
@@ -50,7 +50,6 @@ class CreateTableRequestBuilderTest {
 
     @BeforeEach
     void beforeEach() {
-
         testBuilder = CreateTableRequestBuilder.builder()
             .withTableName("testBuilder")
             .withTableKeySchema(HASH_KEY_FIELD, S, RANGE_KEY_FIELD, S);

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/CreateTableRequestBuilderTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/CreateTableRequestBuilderTest.java
@@ -4,17 +4,19 @@ import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
 import static com.salesforce.dynamodbv2.mt.mappers.index.DynamoSecondaryIndex.DynamoSecondaryIndexType.GSI;
 import static com.salesforce.dynamodbv2.mt.mappers.index.DynamoSecondaryIndex.DynamoSecondaryIndexType.LSI;
 import static java.util.Optional.empty;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.amazonaws.services.dynamodbv2.model.BillingMode;
-import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
 import com.salesforce.dynamodbv2.mt.mappers.index.DynamoSecondaryIndex;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.PrimaryKey;
+import com.salesforce.dynamodbv2.mt.util.DynamoDbTestUtils;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class CreateTableRequestBuilderTest {
 
@@ -26,63 +28,71 @@ class CreateTableRequestBuilderTest {
 
     private CreateTableRequestBuilder testBuilder;
 
-    void assertGlobalSecondaryIndexProvisionedThroughputResults(GlobalSecondaryIndex gsi,
-                                                                Long expectedProvisionedThroughput) {
-        assertNotNull(gsi.getProvisionedThroughput());
-        assert (gsi.getProvisionedThroughput().getReadCapacityUnits().equals(expectedProvisionedThroughput));
-        assert (gsi.getProvisionedThroughput().getWriteCapacityUnits().equals(expectedProvisionedThroughput));
+    private static Stream<Arguments> arguments() {
+        return Stream.of(
+            Arguments.of(new ProvisionedThroughput(5L, 5L), BillingMode.PAY_PER_REQUEST),
+            Arguments.of(new ProvisionedThroughput(5L, 5L), BillingMode.PROVISIONED),
+            Arguments.of(new ProvisionedThroughput(5L, 5L), null),
+
+            Arguments.of(new ProvisionedThroughput(1L, 1L), BillingMode.PAY_PER_REQUEST),
+            Arguments.of(new ProvisionedThroughput(1L, 1L), BillingMode.PROVISIONED),
+            Arguments.of(new ProvisionedThroughput(1L, 1L), null),
+
+            Arguments.of(new ProvisionedThroughput(0L, 0L), BillingMode.PAY_PER_REQUEST),
+            Arguments.of(new ProvisionedThroughput(0L, 0L), BillingMode.PROVISIONED),
+            Arguments.of(new ProvisionedThroughput(0L, 0L), null),
+
+            Arguments.of(null, BillingMode.PAY_PER_REQUEST),
+            Arguments.of(null, BillingMode.PROVISIONED),
+            Arguments.of(null, null)
+        );
     }
 
     @BeforeEach
     void beforeEach() {
 
         testBuilder = CreateTableRequestBuilder.builder()
-                .withTableName("testBuilder")
-                .withTableKeySchema(HASH_KEY_FIELD, S, RANGE_KEY_FIELD, S);
+            .withTableName("testBuilder")
+            .withTableKeySchema(HASH_KEY_FIELD, S, RANGE_KEY_FIELD, S);
 
         indexType = GSI;
         ScalarAttributeType hashKeyType = S;
         Optional<ScalarAttributeType> rangeKeyType = empty();
 
         indexName = indexType.name().toLowerCase() + "_"
-                + hashKeyType.name().toLowerCase()
-                + rangeKeyType.map(type -> "_" + type.name().toLowerCase()).orElse("").toLowerCase();
+            + hashKeyType.name().toLowerCase()
+            + rangeKeyType.map(type -> "_" + type.name().toLowerCase()).orElse("").toLowerCase();
         primaryKey = rangeKeyType.map(
             scalarAttributeType -> new PrimaryKey(indexType == LSI ? "hk" : indexName + "_hk",
-                    hashKeyType,
-                    indexName + "_rk",
-                    scalarAttributeType))
+                hashKeyType,
+                indexName + "_rk",
+                scalarAttributeType))
             .orElseGet(() -> new PrimaryKey(indexName + "_hk",
-                    hashKeyType));
+                hashKeyType));
     }
 
-    @Test
-    void testGlobalSecondaryIndexProvisionedThroughputIsNullForPayPerRequest() {
-        testBuilder.withBillingMode(BillingMode.PAY_PER_REQUEST);
-        testBuilder.addSi(indexName, indexType, primaryKey, 5L);
+    @ParameterizedTest(name = "{index} => capacityUnits={0}, expectedBillingMode={1}")
+    @MethodSource("arguments")
+    void testExpectedBillingMode(ProvisionedThroughput inputProvisionedThroughput, BillingMode expectedBillingMode) {
 
-        for (GlobalSecondaryIndex gsi: testBuilder.getCreateTableRequest().getGlobalSecondaryIndexes()) {
-            assertNull(gsi.getProvisionedThroughput());
+        Long expectedCapacityUnits = null;
+        if (inputProvisionedThroughput != null && (expectedBillingMode == null
+            || expectedBillingMode.equals(BillingMode.PROVISIONED))) {
+
+            expectedCapacityUnits = inputProvisionedThroughput.getReadCapacityUnits();
+            testBuilder.withProvisionedThroughput(expectedCapacityUnits, expectedCapacityUnits);
         }
-    }
 
-    @Test
-    void testGlobalSecondaryIndexProvisionedThroughputIsSetForNullBillingMode() {
-        testBuilder.withBillingMode(null);
-        testBuilder.addSi(indexName, indexType, primaryKey, 5L);
-
-        for (GlobalSecondaryIndex gsi: testBuilder.getCreateTableRequest().getGlobalSecondaryIndexes()) {
-            assertGlobalSecondaryIndexProvisionedThroughputResults(gsi, 5L);
+        if (inputProvisionedThroughput == null && (expectedBillingMode == null
+                || expectedBillingMode.equals(BillingMode.PROVISIONED))) {
+            expectedCapacityUnits = 1L;
         }
-    }
 
-    @Test
-    void testGlobalSecondaryIndexProvisionedThroughputIsSetForProvisioned() {
-        testBuilder.withBillingMode(BillingMode.PROVISIONED);
-        testBuilder.addSi(indexName, indexType, primaryKey, 5L);
+        testBuilder.withBillingMode(expectedBillingMode);
+        testBuilder.addSi(indexName, indexType, primaryKey, expectedCapacityUnits);
+        testBuilder.build();
 
-        for (GlobalSecondaryIndex gsi: testBuilder.getCreateTableRequest().getGlobalSecondaryIndexes()) {
-            assertGlobalSecondaryIndexProvisionedThroughputResults(gsi, 5L);
-        }
+        DynamoDbTestUtils.assertExpectedBillingModeIsSet(
+            testBuilder.getCreateTableRequest(), expectedBillingMode, expectedCapacityUnits);
     }
 }

--- a/src/test/java/com/salesforce/dynamodbv2/mt/util/DynamoDbCapacityTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/util/DynamoDbCapacityTest.java
@@ -38,8 +38,7 @@ class DynamoDbCapacityTest {
 
     private static Stream<Arguments> argumentsBillingModeSetOnRequest() {
         return Stream.of(
-
-            // Test when a request already has something set
+            // Test when a request already has BillingMode set
             Arguments.of(BillingMode.PAY_PER_REQUEST, null, BillingMode.PAY_PER_REQUEST),
             Arguments.of(BillingMode.PAY_PER_REQUEST, null, BillingMode.PROVISIONED),
             Arguments.of(BillingMode.PROVISIONED, null, BillingMode.PAY_PER_REQUEST),
@@ -51,7 +50,6 @@ class DynamoDbCapacityTest {
 
     private static Stream<Arguments> argumentsCapacitySetOnRequest() {
         return Stream.of(
-
             // Test when a request already has provisioned throughput set that provisioned throughput remains set
             Arguments.of(BillingMode.PAY_PER_REQUEST, new ProvisionedThroughput(5L, 5L)),
             Arguments.of(BillingMode.PAY_PER_REQUEST, new ProvisionedThroughput(1L, 1L)),
@@ -69,9 +67,6 @@ class DynamoDbCapacityTest {
 
     private static Stream<Arguments> argumentsNothingSetOnRequest() {
         return Stream.of(
-
-            // Test when a request already has provisioned throughput set that provisioned throughput remains set
-
             Arguments.of(BillingMode.PAY_PER_REQUEST, null, BillingMode.PAY_PER_REQUEST),
             Arguments.of(BillingMode.PROVISIONED, null, BillingMode.PROVISIONED),
             Arguments.of(null, null, BillingMode.PROVISIONED)
@@ -84,7 +79,6 @@ class DynamoDbCapacityTest {
     void testBillingModeWhenCreateTableRequestBillingModeIsSet(BillingMode billingModeInput,
                                                                ProvisionedThroughput inputProvisionedThroughput,
                                                                BillingMode expectedBillingMode) {
-
         assertNull(inputProvisionedThroughput);
 
         // Set Billing Mode for the create table request
@@ -102,7 +96,6 @@ class DynamoDbCapacityTest {
     void testBillingModeWhenCreateTableRequestProvisionedThroughputIsSet(BillingMode billingModeInput,
                                                                          ProvisionedThroughput
                                                                              inputProvisionedThroughput) {
-
         assertNotNull(inputProvisionedThroughput);
         String startingBillingMode = request.getBillingMode();
         assertNull(startingBillingMode);

--- a/src/test/java/com/salesforce/dynamodbv2/mt/util/DynamoDbCapacityTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/util/DynamoDbCapacityTest.java
@@ -3,7 +3,6 @@ package com.salesforce.dynamodbv2.mt.util;
 import static com.amazonaws.services.dynamodbv2.model.KeyType.HASH;
 import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -12,8 +11,12 @@ import com.amazonaws.services.dynamodbv2.model.BillingMode;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
 import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class DynamoDbCapacityTest {
 
@@ -22,13 +25,6 @@ class DynamoDbCapacityTest {
     private static final String ID_ATTR_NAME = "id";
     private static final String INDEX_ID_ATTR_NAME = "indexId";
     private CreateTableRequest request;
-
-    void assertProvisionedThroughputResults(CreateTableRequest request, Long expectedProvisionedThroughput) {
-        assertNotEquals(BillingMode.PAY_PER_REQUEST.toString(), request.getBillingMode());
-        assertNotNull(request.getProvisionedThroughput());
-        assert (request.getProvisionedThroughput().getReadCapacityUnits().equals(expectedProvisionedThroughput));
-        assert (request.getProvisionedThroughput().getWriteCapacityUnits().equals(expectedProvisionedThroughput));
-    }
 
     @BeforeEach
     void beforeEach() {
@@ -40,7 +36,100 @@ class DynamoDbCapacityTest {
                         new AttributeDefinition(INDEX_ID_ATTR_NAME, S));
     }
 
-    // Tests if createTableRequest.BillingMode is already set to PAY_PER_REQUEST, then billing mode shouldn't change
+    private static Stream<Arguments> argumentsBillingModeSetOnRequest() {
+        return Stream.of(
+
+            // Test when a request already has something set
+            Arguments.of(BillingMode.PAY_PER_REQUEST, null, BillingMode.PAY_PER_REQUEST),
+            Arguments.of(BillingMode.PAY_PER_REQUEST, null, BillingMode.PROVISIONED),
+            Arguments.of(BillingMode.PROVISIONED, null, BillingMode.PAY_PER_REQUEST),
+            Arguments.of(BillingMode.PROVISIONED, null, BillingMode.PROVISIONED),
+            Arguments.of(null, null, BillingMode.PAY_PER_REQUEST),
+            Arguments.of(null, null, BillingMode.PROVISIONED)
+        );
+    }
+
+    private static Stream<Arguments> argumentsCapacitySetOnRequest() {
+        return Stream.of(
+
+            // Test when a request already has provisioned throughput set that provisioned throughput remains set
+            Arguments.of(BillingMode.PAY_PER_REQUEST, new ProvisionedThroughput(5L, 5L)),
+            Arguments.of(BillingMode.PAY_PER_REQUEST, new ProvisionedThroughput(1L, 1L)),
+            Arguments.of(BillingMode.PAY_PER_REQUEST, new ProvisionedThroughput(0L, 0L)),
+
+            Arguments.of(BillingMode.PROVISIONED, new ProvisionedThroughput(5L, 5L)),
+            Arguments.of(BillingMode.PROVISIONED, new ProvisionedThroughput(1L, 1L)),
+            Arguments.of(BillingMode.PROVISIONED, new ProvisionedThroughput(0L, 0L)),
+
+            Arguments.of(null, new ProvisionedThroughput(5L, 5L)),
+            Arguments.of(null, new ProvisionedThroughput(1L, 1L)),
+            Arguments.of(null, new ProvisionedThroughput(0L, 0L))
+        );
+    }
+
+    private static Stream<Arguments> argumentsNothingSetOnRequest() {
+        return Stream.of(
+
+            // Test when a request already has provisioned throughput set that provisioned throughput remains set
+
+            Arguments.of(BillingMode.PAY_PER_REQUEST, null, BillingMode.PAY_PER_REQUEST),
+            Arguments.of(BillingMode.PROVISIONED, null, BillingMode.PROVISIONED),
+            Arguments.of(null, null, BillingMode.PROVISIONED)
+        );
+    }
+
+    @ParameterizedTest(name = "{index} => billingModeInput={0}, requestProvisionedThroughput={1}, "
+        + "requestBillingMode={2}")
+    @MethodSource("argumentsBillingModeSetOnRequest")
+    void testBillingModeWhenCreateTableRequestBillingModeIsSet(BillingMode billingModeInput,
+                                                               ProvisionedThroughput inputProvisionedThroughput,
+                                                               BillingMode expectedBillingMode) {
+
+        assertNull(inputProvisionedThroughput);
+
+        // Set Billing Mode for the create table request
+        if (expectedBillingMode != null) {
+            request.withBillingMode(expectedBillingMode);
+        }
+
+        // BillingMode should not be impacted by billingModeInput value since it's already set on the request
+        DynamoDbCapacity.setBillingMode(request, billingModeInput);
+        DynamoDbTestUtils.assertExpectedBillingModeIsSet(request, expectedBillingMode, 1L);
+    }
+
+    @ParameterizedTest(name = "{index} => billingModeInput={0}, requestProvisionedThroughput={1}")
+    @MethodSource("argumentsCapacitySetOnRequest")
+    void testBillingModeWhenCreateTableRequestProvisionedThroughputIsSet(BillingMode billingModeInput,
+                                                                         ProvisionedThroughput
+                                                                             inputProvisionedThroughput) {
+
+        assertNotNull(inputProvisionedThroughput);
+        String startingBillingMode = request.getBillingMode();
+        assertNull(startingBillingMode);
+
+        Long expectedCapacityUnits;
+        expectedCapacityUnits = inputProvisionedThroughput.getReadCapacityUnits();
+        request.withProvisionedThroughput(inputProvisionedThroughput);
+
+        // ProvisionedThroughput should not be impacted by billingModeInput value since it's already set on the request
+        DynamoDbCapacity.setBillingMode(request, billingModeInput);
+        DynamoDbTestUtils.assertExpectedBillingModeIsSet(request, null, expectedCapacityUnits);
+        assertNull(request.getBillingMode());
+    }
+
+    @ParameterizedTest(name = "{index} => billingModeInput={0}, requestProvisionedThroughput={1}, "
+        + "requestBillingMode={2}")
+    @MethodSource("argumentsNothingSetOnRequest")
+    // No BillingMode/ProvisionedThroughput is set on the create table request
+    void testBillingModeWhenCreateTableRequestIsNew(BillingMode billingModeInput,
+                                                    ProvisionedThroughput inputProvisionedThroughput,
+                                                    BillingMode expectedBillingMode) {
+        assertNull(inputProvisionedThroughput);
+
+        DynamoDbCapacity.setBillingMode(request, billingModeInput);
+        DynamoDbTestUtils.assertExpectedBillingModeIsSet(request, expectedBillingMode, 1L);
+    }
+
     @Test
     void testDefaultCapacitySetForNullThroughput() {
         long actual = capacityTest.getCapacity(null, DynamoDbCapacity.CapacityType.READ);
@@ -58,101 +147,6 @@ class DynamoDbCapacityTest {
 
         actual = capacityTest.getCapacity(throughput, DynamoDbCapacity.CapacityType.WRITE);
         assertEquals(10L, actual);
-    }
-
-    @Test
-    void testNoChangeWithBillingModeAlreadyPayPerRequestForInputBillingModeNull() {
-        request.withBillingMode(BillingMode.PAY_PER_REQUEST);
-        DynamoDbCapacity.setBillingMode(request, null);
-        assert (request.getBillingMode().equals(BillingMode.PAY_PER_REQUEST.toString()));
-        assertNull(request.getProvisionedThroughput());
-    }
-
-    @Test
-    void testNoChangeWithBillingModeAlreadyPayPerRequestForInputBillingModePayPerRequest() {
-        request.withBillingMode(BillingMode.PAY_PER_REQUEST);
-        DynamoDbCapacity.setBillingMode(request, BillingMode.PAY_PER_REQUEST);
-        assert (request.getBillingMode().equals(BillingMode.PAY_PER_REQUEST.toString()));
-        assertNull(request.getProvisionedThroughput());
-    }
-
-    @Test
-    void testNoChangeWithBillingModeAlreadyPayPerRequestForInputBillingModeProvisioned() {
-        request.withBillingMode(BillingMode.PAY_PER_REQUEST);
-        DynamoDbCapacity.setBillingMode(request, BillingMode.PROVISIONED);
-        assert (request.getBillingMode().equals(BillingMode.PAY_PER_REQUEST.toString()));
-        assertNull(request.getProvisionedThroughput());
-    }
-
-    // Tests if createTableRequest.BillingMode is already set to PROVISIONED, then billing mode shouldn't change and
-    // throughput should be set if supplied
-    @Test
-    void testNoChangeWithBillingModeAlreadyProvisionedForInputBillingModeNull() {
-        request.withBillingMode(BillingMode.PROVISIONED);
-        DynamoDbCapacity.setBillingMode(request, null);
-        assert (request.getBillingMode().equals(BillingMode.PROVISIONED.toString()));
-        assertProvisionedThroughputResults(request, 1L);
-    }
-
-    @Test
-    void testNoChangeWithBillingModeAlreadyProvisionedForInputBillingModePayPerRequest() {
-        request.withBillingMode(BillingMode.PROVISIONED);
-        DynamoDbCapacity.setBillingMode(request, BillingMode.PAY_PER_REQUEST);
-        assert (request.getBillingMode().equals(BillingMode.PROVISIONED.toString()));
-        assertProvisionedThroughputResults(request, 1L);
-    }
-
-    @Test
-    void testNoChangeWithBillingModeAlreadyProvisionedForInputBillingModeProvisioned() {
-        request.withBillingMode(BillingMode.PROVISIONED);
-        DynamoDbCapacity.setBillingMode(request, BillingMode.PROVISIONED);
-        assert (request.getBillingMode().equals(BillingMode.PROVISIONED.toString()));
-        assertProvisionedThroughputResults(request, 1L);
-    }
-
-    // Tests if createTableRequest.ProvisionedThroughput is already set then ProvisionedThroughtput doesn't change
-    @Test
-    void testNoChangeWithProvisionedThroughputAlreadySetForInputBillingModeNull() {
-        request.withProvisionedThroughput(new ProvisionedThroughput(5L, 5L));
-        DynamoDbCapacity.setBillingMode(request, null);
-        assertProvisionedThroughputResults(request, 5L);
-    }
-
-    @Test
-    void testNoChangeWithProvisionedThroughputAlreadySetForInputBillingModePayPerRequest() {
-        request.withProvisionedThroughput(new ProvisionedThroughput(5L, 5L));
-        DynamoDbCapacity.setBillingMode(request, BillingMode.PAY_PER_REQUEST);
-        assertProvisionedThroughputResults(request, 5L);
-    }
-
-    @Test
-    void testNoChangeWithProvisionedThroughputAlreadySetForInputBillingModeProvisioned() {
-        request.withProvisionedThroughput(new ProvisionedThroughput(5L, 5L));
-        DynamoDbCapacity.setBillingMode(request, BillingMode.PROVISIONED);
-        assertProvisionedThroughputResults(request, 5L);
-    }
-
-    // Tests if createTableRequest is a fresh request (no billing mode/provisioned throughput set that the input values
-    // are used to determine the proper billing mode/provisioned throughput
-    @Test
-    void testBillingModePayPerRequestForInputBillingModePayPerRequestAndProvisionedThroughputNull() {
-        DynamoDbCapacity.setBillingMode(request, BillingMode.PAY_PER_REQUEST);
-        assert (request.getBillingMode().equals(BillingMode.PAY_PER_REQUEST.toString()));
-        assertNull(request.getProvisionedThroughput());
-    }
-
-    @Test
-    void testBillingModeProvisionedForInputBillingModeNullAndProvisionedThroughputNull() {
-        DynamoDbCapacity.setBillingMode(request, null);
-        assert (request.getBillingMode().equals(BillingMode.PROVISIONED.toString()));
-        assertProvisionedThroughputResults(request, 1L);
-    }
-
-    @Test
-    void testBillingModeProvisionedForInputBillingModeProvisionedAndProvisionedThroughputNull() {
-        DynamoDbCapacity.setBillingMode(request, BillingMode.PROVISIONED);
-        assert (request.getBillingMode().equals(BillingMode.PROVISIONED.toString()));
-        assertProvisionedThroughputResults(request, 1L);
     }
 }
 

--- a/src/test/java/com/salesforce/dynamodbv2/mt/util/DynamoDbTestUtils.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/util/DynamoDbTestUtils.java
@@ -72,7 +72,7 @@ public class DynamoDbTestUtils {
 
     /**
      * For an expected billing mode, check that the table has the expected billing mode set as well as associated
-     * provisionedThroughput set where applicable
+     * provisionedThroughput set where applicable.
      * @param request the CreateTableRequest
      * @param expectedBillingMode the expected BillingMode
      * @param expectedProvisionedThroughput the expected ProvisionedThroughput value

--- a/src/test/java/com/salesforce/dynamodbv2/mt/util/DynamoDbTestUtils.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/util/DynamoDbTestUtils.java
@@ -1,10 +1,13 @@
 package com.salesforce.dynamodbv2.mt.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.BillingMode;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.TableDescription;
 
 import java.util.List;
@@ -58,11 +61,58 @@ public class DynamoDbTestUtils {
         }
     }
 
-    public static String getTableNameWithPrefix(String tablePrefix, String tableName, String delimeter) {
-        return tablePrefix + delimeter + tableName;
+    public static String getTableNameWithPrefix(String tablePrefix, String tableName, String delimiter) {
+        return tablePrefix + delimiter + tableName;
     }
 
     public static String getTimestampTableName() {
         return String.valueOf(System.currentTimeMillis());
     }
+
+
+    /**
+     * For an expected billing mode, check that the table has the expected billing mode set as well as associated
+     * provisionedThroughput set where applicable
+     * @param request the CreateTableRequest
+     * @param expectedBillingMode the expected BillingMode
+     * @param expectedProvisionedThroughput the expected ProvisionedThroughput value
+     */
+    public static void assertExpectedBillingModeIsSet(CreateTableRequest request, BillingMode expectedBillingMode,
+                                                Long expectedProvisionedThroughput) {
+
+        if (expectedBillingMode == null || expectedBillingMode.equals(BillingMode.PROVISIONED)) {
+
+            assertNotEquals(BillingMode.PAY_PER_REQUEST.toString(), request.getBillingMode());
+
+            if (expectedBillingMode == null) {
+                assertNull(request.getBillingMode());
+            } else {
+                assert (expectedBillingMode.name().equals(request.getBillingMode()));
+            }
+
+            assertNotNull(request.getProvisionedThroughput());
+            assert (request.getProvisionedThroughput().getReadCapacityUnits().equals(expectedProvisionedThroughput));
+            assert (request.getProvisionedThroughput().getWriteCapacityUnits().equals(expectedProvisionedThroughput));
+
+            if (request.getGlobalSecondaryIndexes() != null) {
+                request.getGlobalSecondaryIndexes()
+                    .forEach(gsi -> {
+                        assertNotNull(gsi.getProvisionedThroughput());
+                        assertEquals(expectedProvisionedThroughput,
+                            gsi.getProvisionedThroughput().getReadCapacityUnits());
+                        assertEquals(expectedProvisionedThroughput,
+                            gsi.getProvisionedThroughput().getWriteCapacityUnits());
+                    });
+            }
+        } else {
+            assert (BillingMode.PAY_PER_REQUEST.name().equals(request.getBillingMode()));
+            assertNull(request.getProvisionedThroughput());
+
+            if (request.getGlobalSecondaryIndexes() != null) {
+                request.getGlobalSecondaryIndexes()
+                    .forEach(gsi -> assertNull(gsi.getProvisionedThroughput()));
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
- updated some tests to be parameterized
- included test to reproduce comparison finding from code-cleanup branch (CreateTableRequestBuilderTest: test # 11 - Arguments.of(null, BillingMode.PROVISIONED))