### PR TITLE
Cache empty results and reduce overlapping reads

### DIFF
--- a/src/main/java/com/salesforce/dynamodbv2/mt/util/CachingAmazonDynamoDbStreams.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/util/CachingAmazonDynamoDbStreams.java
@@ -592,6 +592,7 @@ public class CachingAmazonDynamoDbStreams extends DelegatingAmazonDynamoDbStream
         this.recordCache = new StreamsRecordCache(meterRegistry, maxRecordsByteSize);
         this.iteratorCache = CacheBuilder.newBuilder()
             .maximumSize(maxIteratorCacheSize)
+            .recordStats()
             .build(CacheLoader.from(this::loadShardIterator));
 
         final String cn = CachingAmazonDynamoDbStreams.class.getSimpleName();

--- a/src/main/java/com/salesforce/dynamodbv2/mt/util/StreamsRecordCache.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/util/StreamsRecordCache.java
@@ -274,7 +274,7 @@ class StreamsRecordCache {
         this.maxRecordsByteSize = maxRecordsByteSize;
         this.segments = new ConcurrentHashMap<>();
         this.insertionOrder = new ConcurrentLinkedQueue<>();
-        this.shardLocks = Striped.lazyWeakReadWriteLock(16384);
+        this.shardLocks = Striped.lazyWeakReadWriteLock(1024);
         this.size = new AtomicLong(0L);
         this.byteSize = new AtomicLong(0L);
 

--- a/src/main/java/com/salesforce/dynamodbv2/mt/util/StreamsRecordCache.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/util/StreamsRecordCache.java
@@ -268,7 +268,7 @@ class StreamsRecordCache {
     private final DistributionSummary putRecordsSize;
     private final DistributionSummary putRecordsDiscardedSize;
     private final Timer evictRecordsTimer;
-    private final Counter evictRecordsSize;
+    private final DistributionSummary evictRecordsSize;
 
     StreamsRecordCache(long maxRecordsByteSize) {
         this(new CompositeMeterRegistry(), maxRecordsByteSize);
@@ -291,7 +291,7 @@ class StreamsRecordCache {
         this.putRecordsSize = meterRegistry.summary(className + ".PutRecords.Size");
         this.putRecordsDiscardedSize = meterRegistry.summary(className + ".PutRecords.Discarded.Size");
         this.evictRecordsTimer = meterRegistry.timer(className + ".EvictRecords.Time");
-        this.evictRecordsSize = meterRegistry.counter(className + ".EvictRecords.Size");
+        this.evictRecordsSize = meterRegistry.summary(className + ".EvictRecords.Size");
         meterRegistry.gauge(className + ".size", size);
         meterRegistry.gauge(className + ".byteSize", byteSize);
     }
@@ -443,7 +443,7 @@ class StreamsRecordCache {
                     }
                 }
             }
-            evictRecordsSize.increment(numEvicted);
+            evictRecordsSize.record(numEvicted);
         });
     }
 

--- a/src/main/java/com/salesforce/dynamodbv2/mt/util/StreamsRecordCache.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/util/StreamsRecordCache.java
@@ -11,7 +11,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Striped;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -29,7 +28,6 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -261,10 +259,8 @@ class StreamsRecordCache {
     private final AtomicLong byteSize;
     // meters for observability
     private final Timer getRecordsTime;
-    private final Timer getRecordsWaitTime;
     private final DistributionSummary getRecordsHitSize;
     private final Timer putRecordsTime;
-    private final Timer putRecordsWaitTime;
     private final DistributionSummary putRecordsSize;
     private final DistributionSummary putRecordsDiscardedSize;
     private final Timer evictRecordsTimer;
@@ -278,16 +274,14 @@ class StreamsRecordCache {
         this.maxRecordsByteSize = maxRecordsByteSize;
         this.segments = new ConcurrentHashMap<>();
         this.insertionOrder = new ConcurrentLinkedQueue<>();
-        this.shardLocks = Striped.lazyWeakReadWriteLock(1000);
+        this.shardLocks = Striped.lazyWeakReadWriteLock(16384);
         this.size = new AtomicLong(0L);
         this.byteSize = new AtomicLong(0L);
 
         final String className = StreamsRecordCache.class.getSimpleName();
         this.getRecordsTime = meterRegistry.timer(className + ".GetRecords.Time");
-        this.getRecordsWaitTime = meterRegistry.timer(className + ".GetRecords.Wait.Time");
         this.getRecordsHitSize = meterRegistry.summary(className + ".GetRecords.Hit.Size");
         this.putRecordsTime = meterRegistry.timer(className + ".PutRecords.Time");
-        this.putRecordsWaitTime = meterRegistry.timer(className + ".PutRecords.Wait.Time");
         this.putRecordsSize = meterRegistry.summary(className + ".PutRecords.Size");
         this.putRecordsDiscardedSize = meterRegistry.summary(className + ".PutRecords.Discarded.Size");
         this.evictRecordsTimer = meterRegistry.timer(className + ".EvictRecords.Time");
@@ -297,52 +291,52 @@ class StreamsRecordCache {
     }
 
     /**
-     * Returns the cached segment that contains the given shard location. If no such segment exists, returns empty.
+     * Returns the set of records cached for the given shard location.
      *
-     * @param iteratorPosition Shard location for which to return the cached segment that contains it.
-     * @return Segment that contains the given location or empty.
+     * @param iteratorPosition Shard location for which to return cached records.
+     * @return List of records cached. Empty if none cached
      */
-    Optional<List<Record>> getRecords(StreamShardPosition iteratorPosition, int limit) {
+    List<Record> getRecords(StreamShardPosition iteratorPosition, int limit) {
         return getRecordsTime.record(() -> {
             checkArgument(iteratorPosition != null && limit > 0);
 
-            final Optional<List<Record>> records;
+            final List<Record> records;
             final StreamShardId streamShardId = iteratorPosition.getStreamShardId();
             final ReadWriteLock lock = shardLocks.get(streamShardId);
-
             final Lock readLock = lock.readLock();
-            final long waitTime = time(readLock::lock); // timing manually to avoid calling record in critical section
+            readLock.lock();
             try {
                 records = innerGetRecords(streamShardId, iteratorPosition.getSequenceNumber(), limit);
             } finally {
                 readLock.unlock();
-                getRecordsWaitTime.record(waitTime, TimeUnit.NANOSECONDS);
             }
 
             // record cache hit, including size
-            records.map(List::size).ifPresent(getRecordsHitSize::record);
+            if (!records.isEmpty()) {
+                getRecordsHitSize.record(records.size());
+            }
 
             return records;
         });
     }
 
     // inner helper method must be called with lock held
-    private Optional<List<Record>> innerGetRecords(StreamShardId streamShardId, BigInteger sequenceNumber, int limit) {
+    private List<Record> innerGetRecords(StreamShardId streamShardId, BigInteger sequenceNumber, int limit) {
         final NavigableMap<BigInteger, Segment> shardCache = segments.get(streamShardId);
         if (shardCache == null) {
             // nothing cached for the requested shard
-            return Optional.empty();
+            return Collections.emptyList();
         }
         final Entry<BigInteger, Segment> entry = shardCache.floorEntry(sequenceNumber);
         if (entry == null) {
             // no segment with requested or smaller sequence number exists
-            return Optional.empty();
+            return Collections.emptyList();
         }
         final Segment segment = entry.getValue();
         if (segment.getEnd().compareTo(sequenceNumber) <= 0) {
             // preceding segment does not contain requested sequence number (which means there are no records cached yet
             // for the requested sequence number, since otherwise floorEntry would have returned the next higher entry)
-            return Optional.empty();
+            return Collections.emptyList();
         }
 
         // preceding segment contains (some) records for the requested sequence number
@@ -360,7 +354,7 @@ class StreamsRecordCache {
             addAll(innerRecords, next.getRecords(), limit);
         }
 
-        return Optional.of(Collections.unmodifiableList(innerRecords));
+        return Collections.unmodifiableList(innerRecords);
     }
 
     // Should we bring back segment merging to avoid cache fragmentation?
@@ -375,7 +369,7 @@ class StreamsRecordCache {
             final StreamShardId streamShardId = iteratorPosition.getStreamShardId();
             final ReadWriteLock lock = shardLocks.get(streamShardId);
             final Lock writeLock = lock.writeLock();
-            final long waitTime = time(writeLock::lock);
+            writeLock.lock();
             try {
                 final NavigableMap<BigInteger, Segment> shardCache =
                     segments.computeIfAbsent(streamShardId, k -> new TreeMap<>());
@@ -395,7 +389,6 @@ class StreamsRecordCache {
                 }
             } finally {
                 writeLock.unlock();
-                putRecordsWaitTime.record(waitTime, TimeUnit.NANOSECONDS);
             }
 
             putRecordsSize.record(cacheSegment.getRecords().size());
@@ -461,13 +454,6 @@ class StreamsRecordCache {
         } else {
             list.addAll(toAdd.subList(0, remaining));
         }
-    }
-
-    // helper for timing a runnable
-    private static long time(Runnable runnable) {
-        final long before = System.nanoTime();
-        runnable.run();
-        return System.nanoTime() - before;
     }
 
 }

--- a/src/test/java/com/salesforce/dynamodbv2/mt/util/CachingAmazonDynamoDbStreamsTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/util/CachingAmazonDynamoDbStreamsTest.java
@@ -752,7 +752,7 @@ class CachingAmazonDynamoDbStreamsTest {
 
         Sleeper sleeper = mock(Sleeper.class);
         CachingAmazonDynamoDbStreams cachingStreams = new CachingAmazonDynamoDbStreams.Builder(streams)
-            .withGetRecordsLimitExceededBackoffInMillis(10000L)
+            .withGetRecordsBackoffInMillis(10000L)
             .withSleeper(sleeper)
             .build();
 
@@ -780,8 +780,8 @@ class CachingAmazonDynamoDbStreamsTest {
 
         Sleeper sleeper = mock(Sleeper.class);
         CachingAmazonDynamoDbStreams cachingStreams = new CachingAmazonDynamoDbStreams.Builder(streams)
-            .withGetRecordsLimitExceededBackoffInMillis(500)
-            .withMaxGetRecordsRetries(3)
+            .withGetRecordsBackoffInMillis(500)
+            .withGetRecordsMaxRetries(3)
             .withSleeper(sleeper)
             .withMaxRecordsByteSize(100L)
             .build();
@@ -820,7 +820,7 @@ class CachingAmazonDynamoDbStreamsTest {
 
         Sleeper sleeper = mock(Sleeper.class);
         CachingAmazonDynamoDbStreams cachingStreams = new CachingAmazonDynamoDbStreams.Builder(streams)
-            .withMaxGetRecordsRetries(1)
+            .withGetRecordsMaxRetries(1)
             .withSleeper(sleeper)
             .build();
 

--- a/src/test/java/com/salesforce/dynamodbv2/mt/util/CachingAmazonDynamoDbStreamsTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/util/CachingAmazonDynamoDbStreamsTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -59,6 +60,7 @@ import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Striped;
 import com.salesforce.dynamodbv2.dynamodblocal.AmazonDynamoDbLocal;
 import com.salesforce.dynamodbv2.mt.util.CachingAmazonDynamoDbStreams.Sleeper;
 import com.salesforce.dynamodbv2.testsupport.CountingAmazonDynamoDbStreams;
@@ -70,6 +72,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
 import java.util.stream.IntStream;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.AfterAll;
@@ -112,12 +116,7 @@ class CachingAmazonDynamoDbStreamsTest {
         CountingAmazonDynamoDbStreams countingDynamoDbStreams = new CountingAmazonDynamoDbStreams(dynamoDbStreams);
         CachingAmazonDynamoDbStreams cachingDynamoDbStreams = new CachingAmazonDynamoDbStreams
             .Builder(countingDynamoDbStreams)
-            .withTicker(new Ticker() {
-                @Override
-                public long read() {
-                    return 0L;
-                }
-            })
+            .withTicker(new MockTicker())
             .build();
 
         // setup: create a table with streams enabled
@@ -272,6 +271,17 @@ class CachingAmazonDynamoDbStreamsTest {
             // cleanup after ourselves (want to be able to run against hosted DynamoDB as well)
             dynamoDb.deleteTable(tableName);
         }
+    }
+
+    private static class MockTicker extends Ticker {
+
+        long nanos;
+
+        @Override
+        public long read() {
+            return nanos;
+        }
+
     }
 
     // some test fixtures
@@ -1119,6 +1129,218 @@ class CachingAmazonDynamoDbStreamsTest {
 
         assertThrows(ResourceNotFoundException.class,
             () -> cachingStreams.getRecords(new GetRecordsRequest().withShardIterator(iterator)));
+    }
+
+    /**
+     * Verifies that empty results are cached for a while.
+     */
+    @Test
+    void testEmptyRecordsCache() {
+        final AmazonDynamoDBStreams streams = mock(AmazonDynamoDBStreams.class);
+        final GetShardIteratorRequest request = newAfterSequenceNumberRequest(0);
+        final String dynamoDbIterator = mockGetShardIterator(streams, request);
+        final String nextDynamoDbIteator = mockShardIterator(request);
+        mockGetRecords(streams, dynamoDbIterator, Collections.emptyList(), nextDynamoDbIteator);
+        mockGetRecords(streams, nextDynamoDbIteator, 0, 1);
+
+        final MockTicker ticker = new MockTicker();
+        final CachingAmazonDynamoDbStreams cachingStreams = new CachingAmazonDynamoDbStreams.Builder(streams)
+            .withTicker(ticker)
+            .withEmptyResultCacheTtlInMillis(1)
+            .build();
+
+        // first request should retrieve empty result and then cache it
+        assertGetRecords(cachingStreams, request, null, 0, 0);
+        assertCacheMisses(streams, 1, 1);
+
+        // so second request should not try to fetch again
+        assertGetRecords(cachingStreams, request, null, 0, 0);
+        assertCacheMisses(streams, 1, 1);
+
+        // after clock advances, empty result should get evicted
+        ticker.nanos += 1000000;
+        assertGetRecords(cachingStreams, request, null, 0, 1);
+        assertCacheMisses(streams, 1, 2);
+    }
+
+    /**
+     * Verifies that empty records cache is used even for concurrent access (by simulating locks).
+     */
+    @Test
+    void testConcurrentEmptyGetRecordsResult() throws InterruptedException {
+        final AmazonDynamoDBStreams streams = mock(AmazonDynamoDBStreams.class);
+        final GetShardIteratorRequest request = newAfterSequenceNumberRequest(0);
+        final String dynamoDbIterator = mockGetShardIterator(streams, request);
+        final String nextDynamoDbIteator = mockShardIterator(request);
+        mockGetRecords(streams, dynamoDbIterator, Collections.emptyList(), nextDynamoDbIteator);
+        mockGetRecords(streams, nextDynamoDbIteator, 0, 1);
+
+        final Lock lock = mock(Lock.class);
+        final Striped<Lock> getRecordsLocks = mock(Striped.class);
+        when(getRecordsLocks.get(any())).thenReturn(lock);
+        final MockTicker ticker = new MockTicker();
+        final CachingAmazonDynamoDbStreams cachingStreams = new CachingAmazonDynamoDbStreams.Builder(streams)
+            .withTicker(ticker)
+            .withEmptyResultCacheTtlInMillis(1)
+            .withGetRecordsLocks(getRecordsLocks)
+            .build();
+
+        // simulate concurrent access
+        final AtomicInteger callCount = new AtomicInteger();
+        when(lock.tryLock(anyLong(), any()))
+            .thenAnswer(invocation -> {
+                // another thread concurrently loads/caches empty result
+                callCount.incrementAndGet();
+                assertGetRecords(cachingStreams, request, null, 0, 0);
+                assertCacheMisses(streams, 1, 1);
+                return true;
+            })
+            .thenReturn(true);
+
+        // while this thread waits for the lock, another thread loads empty result, so this one should not load again
+        assertGetRecords(cachingStreams, request, null, 0, 0);
+        assertCacheMisses(streams, 1, 1);
+        assertEquals(1, callCount.get()); // make simulation behaves correctly (Mockito sanity check)
+
+        // after clock advances, next thread should load results
+        ticker.nanos += 1000000;
+        assertGetRecords(cachingStreams, request, null, 0, 1);
+        assertCacheMisses(streams, 1, 2);
+        assertEquals(1, callCount.get());
+    }
+
+    /**
+     * Verifies that if another thread concurrently loads and populates cache, thread does not attempt to load.
+     */
+    @Test
+    void testConcurrentNonEmptyGetRecordsResult() throws InterruptedException {
+        final AmazonDynamoDBStreams streams = mock(AmazonDynamoDBStreams.class);
+        final GetShardIteratorRequest request = newAfterSequenceNumberRequest(0);
+        final String dynamoDbIterator = mockGetShardIterator(streams, request);
+        mockGetRecords(streams, dynamoDbIterator, 0, 5);
+
+        final Lock lock = mock(Lock.class);
+        final Striped<Lock> getRecordsLocks = mock(Striped.class);
+        when(getRecordsLocks.get(any())).thenReturn(lock);
+        final CachingAmazonDynamoDbStreams cachingStreams = new CachingAmazonDynamoDbStreams.Builder(streams)
+            .withGetRecordsLocks(getRecordsLocks)
+            .build();
+
+        // simulate concurrent access
+        final AtomicInteger callCount = new AtomicInteger();
+        when(lock.tryLock(anyLong(), any()))
+            .thenAnswer(invocation -> {
+                // another thread concurrently loads and caches result
+                callCount.incrementAndGet();
+                assertGetRecords(cachingStreams, request, null, 0, 5);
+                assertCacheMisses(streams, 1, 1);
+                return true;
+            })
+            .thenReturn(true);
+
+        // while this thread waits for lock, another thread loads result into cache, so this one should not load again
+        assertGetRecords(cachingStreams, request, null, 0, 5);
+        assertCacheMisses(streams, 1, 1);
+        assertEquals(1, callCount.get()); // make simulation behaves correctly (Mockito sanity check)
+    }
+
+    /**
+     * Verifies that if a thread times out waiting for a lock, it still returns concurrently loaded empty result.
+     */
+    @Test
+    void testConcurrentEmptyGetRecordsResultWithTimeout() throws InterruptedException {
+        final AmazonDynamoDBStreams streams = mock(AmazonDynamoDBStreams.class);
+        final GetShardIteratorRequest request = newAfterSequenceNumberRequest(0);
+        final String dynamoDbIterator = mockGetShardIterator(streams, request);
+        mockGetRecords(streams, dynamoDbIterator, Collections.emptyList(), mockShardIterator(request));
+
+        final Lock lock = mock(Lock.class);
+        final Striped<Lock> getRecordsLocks = mock(Striped.class);
+        when(getRecordsLocks.get(any())).thenReturn(lock);
+        final MockTicker ticker = new MockTicker();
+        final CachingAmazonDynamoDbStreams cachingStreams = new CachingAmazonDynamoDbStreams.Builder(streams)
+            .withTicker(ticker)
+            .withEmptyResultCacheTtlInMillis(1)
+            .withGetRecordsLocks(getRecordsLocks)
+            .build();
+
+        // simulate concurrent access
+        final AtomicInteger callCount = new AtomicInteger();
+        when(lock.tryLock(anyLong(), any()))
+            .thenAnswer(invocation -> {
+                // another thread concurrently loads/caches empty result
+                callCount.incrementAndGet();
+                assertGetRecords(cachingStreams, request, null, 0, 0);
+                assertCacheMisses(streams, 1, 1);
+                return false; // this simulates a timeout waiting for the lock
+            })
+            .thenReturn(true);
+
+        // while this thread waits for the lock, another thread loads empty result, so this one should not load again
+        assertGetRecords(cachingStreams, request, null, 0, 0);
+        assertCacheMisses(streams, 1, 1);
+        assertEquals(1, callCount.get()); // make simulation behaves correctly (Mockito sanity check)
+    }
+
+    /**
+     * Verifies that if a thread times out waiting for a lock, it still returns concurrently loaded result.
+     */
+    @Test
+    void testConcurrentNonEmptyGetRecordsResultWithTimeout() throws InterruptedException {
+        final AmazonDynamoDBStreams streams = mock(AmazonDynamoDBStreams.class);
+        final GetShardIteratorRequest request = newAfterSequenceNumberRequest(0);
+        final String dynamoDbIterator = mockGetShardIterator(streams, request);
+        mockGetRecords(streams, dynamoDbIterator, 0, 5);
+
+        final Lock lock = mock(Lock.class);
+        final Striped<Lock> getRecordsLocks = mock(Striped.class);
+        when(getRecordsLocks.get(any())).thenReturn(lock);
+        final CachingAmazonDynamoDbStreams cachingStreams = new CachingAmazonDynamoDbStreams.Builder(streams)
+            .withGetRecordsLocks(getRecordsLocks)
+            .build();
+
+        // simulate concurrent access
+        final AtomicInteger callCount = new AtomicInteger();
+        when(lock.tryLock(anyLong(), any()))
+            .thenAnswer(invocation -> {
+                // another thread concurrently loads and caches result
+                callCount.incrementAndGet();
+                assertGetRecords(cachingStreams, request, null, 0, 5);
+                assertCacheMisses(streams, 1, 1);
+                return false;
+            })
+            .thenReturn(true);
+
+        // while this thread waits for lock, another thread loads result into cache, so this one should not load again
+        assertGetRecords(cachingStreams, request, null, 0, 5);
+        assertCacheMisses(streams, 1, 1);
+        assertEquals(1, callCount.get()); // make simulation behaves correctly (Mockito sanity check)
+    }
+
+    /**
+     * Verifies that if a thread times out waiting for a lock and concurrent load has not finished, it returns an empty
+     * result without trying to load records.
+     */
+    @Test
+    void testGetRecordsLockTimeout() throws InterruptedException {
+        final AmazonDynamoDBStreams streams = mock(AmazonDynamoDBStreams.class);
+        final GetShardIteratorRequest request = newAfterSequenceNumberRequest(0);
+        final String dynamoDbIterator = mockGetShardIterator(streams, request);
+        mockGetRecords(streams, dynamoDbIterator, 0, 5);
+
+        final Lock lock = mock(Lock.class);
+        final Striped<Lock> getRecordsLocks = mock(Striped.class);
+        when(getRecordsLocks.get(any())).thenReturn(lock);
+        final CachingAmazonDynamoDbStreams cachingStreams = new CachingAmazonDynamoDbStreams.Builder(streams)
+            .withGetRecordsLocks(getRecordsLocks)
+            .build();
+
+        // simulate concurrent access
+        when(lock.tryLock(anyLong(), any())).thenReturn(false);
+
+        // while this thread waits for lock, another thread loads result into cache, so this one should not load again
+        assertGetRecords(cachingStreams, request, null, 0, 0);
+        assertCacheMisses(streams, 0, 0);
     }
 
     /**


### PR DESCRIPTION
@msgroi  Here is another attempt at fixing the same issue that I think will work better.