### PR TITLE
Fix mapped key in UpdateItem, DeleteItem, and BatchGetItem

### DIFF
--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtAmazonDynamoDbBySharedTable.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtAmazonDynamoDbBySharedTable.java
@@ -250,7 +250,7 @@ public class MtAmazonDynamoDbBySharedTable extends MtAmazonDynamoDbBase {
             qualifiedBatchGetItemRequest.addRequestItemsEntry(
                 qualifiedTableName,
                 new KeysAndAttributes().withKeys(unqualifiedKeys.getKeys().stream().map(
-                    key -> tableMapping.getItemMapper().apply(key)).collect(Collectors.toList())));
+                    key -> tableMapping.getKeyMapper().apply(key)).collect(Collectors.toList())));
         });
 
         // batch get

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtAmazonDynamoDbBySharedTable.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtAmazonDynamoDbBySharedTable.java
@@ -324,7 +324,7 @@ public class MtAmazonDynamoDbBySharedTable extends MtAmazonDynamoDbBase {
         deleteItemRequest.withTableName(tableMapping.getPhysicalTable().getTableName());
 
         // map key
-        deleteItemRequest.setKey(tableMapping.getItemMapper().apply(deleteItemRequest.getKey()));
+        deleteItemRequest.setKey(tableMapping.getKeyMapper().apply(deleteItemRequest.getKey()));
 
         // map conditions
         tableMapping.getConditionMapper().apply(new DeleteItemRequestWrapper(deleteItemRequest));
@@ -588,7 +588,7 @@ public class MtAmazonDynamoDbBySharedTable extends MtAmazonDynamoDbBase {
         updateItemRequest.withTableName(tableMapping.getPhysicalTable().getTableName());
 
         // map key
-        updateItemRequest.setKey(tableMapping.getItemMapper().apply(updateItemRequest.getKey()));
+        updateItemRequest.setKey(tableMapping.getKeyMapper().apply(updateItemRequest.getKey()));
 
         // map conditions
         tableMapping.getConditionMapper().apply(new UpdateItemRequestWrapper(updateItemRequest));

--- a/src/test/java/com/salesforce/dynamodbv2/BatchGetTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/BatchGetTest.java
@@ -3,6 +3,7 @@ package com.salesforce.dynamodbv2;
 import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
 import static com.salesforce.dynamodbv2.testsupport.DefaultTestSetup.TABLE1;
 import static com.salesforce.dynamodbv2.testsupport.DefaultTestSetup.TABLE3;
+import static com.salesforce.dynamodbv2.testsupport.DefaultTestSetup.TABLE5;
 import static com.salesforce.dynamodbv2.testsupport.TestSupport.HASH_KEY_OTHER_VALUE;
 import static com.salesforce.dynamodbv2.testsupport.TestSupport.HASH_KEY_VALUE;
 import static com.salesforce.dynamodbv2.testsupport.TestSupport.RANGE_KEY_OTHER_S_VALUE;
@@ -98,26 +99,36 @@ class BatchGetTest {
     @ParameterizedTest(name = "{arguments}")
     @ArgumentsSource(DefaultArgumentProvider.class)
     void batchGetHkRkTable(TestArgument testArgument) {
+        runBatchGetHkRkTableTest(testArgument, TABLE3);
+    }
+
+    @ParameterizedTest(name = "{arguments}")
+    @ArgumentsSource(DefaultArgumentProvider.class)
+    void batchGetHkRkTableWithPkFieldInGsi(TestArgument testArgument) {
+        runBatchGetHkRkTableTest(testArgument, TABLE5);
+    }
+
+    private void runBatchGetHkRkTableTest(TestArgument testArgument, String tableName) {
         testArgument.forEachOrgContext(
             org -> {
                 final List<String> hashKeyValues = Arrays.asList(HASH_KEY_VALUE, HASH_KEY_VALUE);
                 final List<Optional<String>> rangeKeyValueOpts = Arrays.asList(Optional.of(RANGE_KEY_S_VALUE),
-                        Optional.of(RANGE_KEY_OTHER_S_VALUE));
+                    Optional.of(RANGE_KEY_OTHER_S_VALUE));
                 final Set<Map<String, AttributeValue>> gottenItems = batchGetItem(testArgument.getHashKeyAttrType(),
-                        testArgument.getAmazonDynamoDb(),
-                        TABLE3,
-                        hashKeyValues,
-                        rangeKeyValueOpts);
+                    testArgument.getAmazonDynamoDb(),
+                    tableName,
+                    hashKeyValues,
+                    rangeKeyValueOpts);
                 final Map<String, AttributeValue> expectedItem0 = ItemBuilder.builder(testArgument.getHashKeyAttrType(),
-                            hashKeyValues.get(0))
-                        .someField(S, SOME_FIELD_VALUE + TABLE3 + org)
-                        .rangeKey(S, RANGE_KEY_S_VALUE)
-                        .build();
+                    hashKeyValues.get(0))
+                    .someField(S, SOME_FIELD_VALUE + tableName + org)
+                    .rangeKey(S, RANGE_KEY_S_VALUE)
+                    .build();
                 final Map<String, AttributeValue> expectedItem1 = ItemBuilder.builder(testArgument.getHashKeyAttrType(),
-                            hashKeyValues.get(1))
-                        .someField(S, SOME_OTHER_FIELD_VALUE + TABLE3 + org)
-                        .withDefaults()
-                        .build();
+                    hashKeyValues.get(1))
+                    .someField(S, SOME_OTHER_FIELD_VALUE + tableName + org)
+                    .withDefaults()
+                    .build();
                 assertEquals(ImmutableSet.of(expectedItem0, expectedItem1), gottenItems);
             });
     }


### PR DESCRIPTION
There seems to be a bug in UpdateItem, DeleteItem, and BatchGetItem, when using a shared table, and the virtual table has a secondary index that includes one of the PK fields. To map the request's key, TableMapping.getItemMapper() is being used, so say if the GSI has the PK range key as its HK, the original key would have just the virtual HK and virtual RK, but the mapped key would have the physical HK, physical RK, and the physical GSI HK as well, when we should have only the physical HK and RK.