### PR TITLE
Add timebounds to listBackups API

### DIFF
--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/SharedTableBuilder.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/SharedTableBuilder.java
@@ -342,7 +342,7 @@ public class SharedTableBuilder implements TableBuilder {
             clock,
             tableMappingCache,
             meterRegistry,
-            Optional.ofNullable(backupManagerBuilder),
+            Optional.ofNullable(backupManagerBuilder).map(b -> b.withClock(clock)),
             scanTenantKey,
             scanVirtualTableKey,
             backupTablePrefix);

--- a/src/main/kotlin/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtSharedTableBackupManager.kt
+++ b/src/main/kotlin/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtSharedTableBackupManager.kt
@@ -69,7 +69,7 @@ open class MtSharedTableBackupManager(
     val s3BucketName: String,
     val sharedTableMtDynamo: MtAmazonDynamoDbBySharedTable,
     val tableSnapshotter: MtBackupTableSnapshotter,
-    val clock : Clock
+    val clock: Clock
 ) : MtBackupManager {
     private val logger = LoggerFactory.getLogger(MtSharedTableBackupManager::class.java)
 
@@ -519,12 +519,12 @@ open class MtSharedTableBackupManager(
 data class TenantTableRow(val attributeMap: Map<String, AttributeValue>)
 
 data class MtSharedTableBackupManagerBuilder(val s3: AmazonS3, val s3BucketName: String, val tableSnapshotter: MtBackupTableSnapshotter) {
-    var clock : Clock = Clock.systemUTC()
+    var clock: Clock = Clock.systemUTC()
     fun build(sharedTableMtDynamo: MtAmazonDynamoDbBySharedTable): MtSharedTableBackupManager {
         return MtSharedTableBackupManager(s3, s3BucketName, sharedTableMtDynamo, tableSnapshotter, clock)
     }
 
-    fun withClock(clock : Clock) : MtSharedTableBackupManagerBuilder {
+    fun withClock(clock: Clock): MtSharedTableBackupManagerBuilder {
         this.clock = clock
         return this
     }

--- a/src/main/kotlin/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtSharedTableBackupManager.kt
+++ b/src/main/kotlin/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtSharedTableBackupManager.kt
@@ -55,6 +55,7 @@ import org.slf4j.LoggerFactory
 import java.io.InputStreamReader
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
+import java.time.Clock
 import java.util.ArrayList
 import java.util.HashMap
 import java.util.stream.Collectors
@@ -67,7 +68,8 @@ open class MtSharedTableBackupManager(
     val s3: AmazonS3,
     val s3BucketName: String,
     val sharedTableMtDynamo: MtAmazonDynamoDbBySharedTable,
-    val tableSnapshotter: MtBackupTableSnapshotter
+    val tableSnapshotter: MtBackupTableSnapshotter,
+    val clock : Clock
 ) : MtBackupManager {
     private val logger = LoggerFactory.getLogger(MtSharedTableBackupManager::class.java)
 
@@ -106,7 +108,7 @@ open class MtSharedTableBackupManager(
         if (backup != null) {
             throw MtBackupException("Backup with that ID already exists: $backup")
         } else {
-            val startTime = System.currentTimeMillis()
+            val startTime = clock.millis()
             val virtualMetadata = backupVirtualTableMetadata(createBackupRequest)
             val tenantTableCounts: Map<TenantTableBackupMetadata, Long> = virtualMetadata
                     .map { metadata ->
@@ -128,7 +130,7 @@ open class MtSharedTableBackupManager(
     open fun backupVirtualTableMetadata(
         createBackupRequest: CreateBackupRequest
     ): List<MtTableDescriptionRepo.MtCreateTableRequest> {
-        val startTime = System.currentTimeMillis()
+        val startTime = clock.millis()
         // write out table metadata
         val startKey: TenantTable? = null
         val batchSize = 100
@@ -145,7 +147,7 @@ open class MtSharedTableBackupManager(
             tenantTableCount += listTenantMetadataResult.createTableRequests.size
         } while (listTenantMetadataResult.lastEvaluatedTable != null)
         logger.info("${createBackupRequest.backupName}: Finished generating backup metadata for " +
-                "${tenantTables.size} virtual table in ${System.currentTimeMillis() - startTime} ms")
+                "${tenantTables.size} virtual table in ${clock.millis() - startTime} ms")
         return tenantTables
     }
 
@@ -171,13 +173,13 @@ open class MtSharedTableBackupManager(
         createBackupRequest: CreateBackupRequest,
         physicalTableName: String
     ): MtBackupMetadata {
-        val startTime = System.currentTimeMillis()
+        val startTime = clock.millis()
         val backupMetadata = createBackupData(createBackupRequest, physicalTableName, sharedTableMtDynamo)
         // write out actual backup data
         commitBackupMetadata(backupMetadata)
 
         logger.info("${createBackupRequest.backupName}: Finished generating backup for " +
-                "$physicalTableName in ${System.currentTimeMillis() - startTime} ms")
+                "$physicalTableName in ${clock.millis() - startTime} ms")
         return backupMetadata
     }
 
@@ -210,7 +212,7 @@ open class MtSharedTableBackupManager(
         restoreMtBackupRequest: RestoreMtBackupRequest,
         mtContext: MtAmazonDynamoDbContextProvider
     ): TenantRestoreMetadata {
-        val startTime = System.currentTimeMillis()
+        val startTime = clock.millis()
         // restore tenant-table metadata
         val createTableReq: CreateTableRequest = getTenantTableMetadata(restoreMtBackupRequest.backupName,
                 restoreMtBackupRequest.tenantTableBackup)
@@ -232,7 +234,7 @@ open class MtSharedTableBackupManager(
             }
         }
         logger.info("${restoreMtBackupRequest.backupName}: Finished restoring ${restoreMtBackupRequest.tenantTableBackup}" +
-                " to ${restoreMtBackupRequest.newTenantTable} in ${System.currentTimeMillis() - startTime} ms")
+                " to ${restoreMtBackupRequest.newTenantTable} in ${clock.millis() - startTime} ms")
 
         return TenantRestoreMetadata(restoreMtBackupRequest.backupName,
                 Status.COMPLETE,
@@ -269,8 +271,11 @@ open class MtSharedTableBackupManager(
 
         Preconditions.checkArgument(listBackupRequest.backupType == null, "Listing backups by backupType unsupported")
         Preconditions.checkArgument(listBackupRequest.tableName == null, "Listing backups by table name unsupported for multitenant backups")
-        Preconditions.checkArgument(listBackupRequest.timeRangeLowerBound == null, "Listing backups filtered by time range unsupported [currently]")
-        Preconditions.checkArgument(listBackupRequest.timeRangeUpperBound == null, "Listing backups filtered by time range unsupported [currently]")
+
+        val backupUpperBound: Long = if (listBackupRequest.timeRangeUpperBound == null)
+            Long.MAX_VALUE else listBackupRequest.timeRangeUpperBound.time
+        val backupLowerBound: Long = if (listBackupRequest.timeRangeLowerBound == null)
+            Long.MIN_VALUE else listBackupRequest.timeRangeLowerBound.time
 
         // translate the last backupArn we saw to the file name on S3, to iterate from
         var startAfter: String? = if (listBackupRequest.exclusiveStartBackupArn == null) null
@@ -290,7 +295,10 @@ open class MtSharedTableBackupManager(
             for (o in listBucketResult.objectSummaries) {
                 if (ret.size < limit) {
                     val backup = mtBackupAwsAdaptor.getBackupSummary(getBackup(getBackupIdFromKey(o.key))!!)
-                    ret.add(backup)
+                    val backupTime = backup.backupCreationDateTime.time
+                    if (backupTime in backupLowerBound..backupUpperBound) {
+                        ret.add(backup)
+                    }
                 }
             }
             continuationToken = listBucketResult.nextContinuationToken
@@ -510,8 +518,14 @@ open class MtSharedTableBackupManager(
 
 data class TenantTableRow(val attributeMap: Map<String, AttributeValue>)
 
-class MtSharedTableBackupManagerBuilder(val s3: AmazonS3, val s3BucketName: String, val tableSnapshotter: MtBackupTableSnapshotter) {
+data class MtSharedTableBackupManagerBuilder(val s3: AmazonS3, val s3BucketName: String, val tableSnapshotter: MtBackupTableSnapshotter) {
+    var clock : Clock = Clock.systemUTC()
     fun build(sharedTableMtDynamo: MtAmazonDynamoDbBySharedTable): MtSharedTableBackupManager {
-        return MtSharedTableBackupManager(s3, s3BucketName, sharedTableMtDynamo, tableSnapshotter)
+        return MtSharedTableBackupManager(s3, s3BucketName, sharedTableMtDynamo, tableSnapshotter, clock)
+    }
+
+    fun withClock(clock : Clock) : MtSharedTableBackupManagerBuilder {
+        this.clock = clock
+        return this
     }
 }

--- a/src/test/kotlin/com/salesforce/dynamodbv2/mt/mappers/MtBackupManagerTest.kt
+++ b/src/test/kotlin/com/salesforce/dynamodbv2/mt/mappers/MtBackupManagerTest.kt
@@ -123,19 +123,6 @@ internal class MtBackupManagerTest {
             } catch (ex: IllegalArgumentException) {
                 assertTrue(ex.message!!.contains("Listing backups by table name unsupported for multitenant backups"))
             }
-
-            try {
-                sharedTableBinaryHashKey.listBackups(ListBackupsRequest().withTimeRangeLowerBound(Date()))
-                fail("Should have failed trying to list backups with time ranges") as Unit
-            } catch (ex: IllegalArgumentException) {
-                assertTrue(ex.message!!.contains("Listing backups filtered by time range unsupported"))
-            }
-            try {
-                sharedTableBinaryHashKey.listBackups(ListBackupsRequest().withTimeRangeUpperBound(Date()))
-                fail("Should have failed trying to list backups with time ranges") as Unit
-            } catch (ex: IllegalArgumentException) {
-                assertTrue(ex.message!!.contains("Listing backups filtered by time range unsupported"))
-            }
         }
     }
 }

--- a/src/test/kotlin/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtSharedTableBackupManagerS3It.kt
+++ b/src/test/kotlin/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtSharedTableBackupManagerS3It.kt
@@ -50,8 +50,12 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito
 import java.nio.ByteBuffer
-import java.util.ArrayList
+import java.time.Clock
+import java.util.*
+import java.util.concurrent.TimeUnit
 import java.util.function.Supplier
 import java.util.stream.Collectors
 
@@ -255,25 +259,55 @@ internal class MtSharedTableBackupManagerS3It {
 
     @Test
     fun testListTenantBackups() {
-        val tenant1 = "tenant-1"
-        val tenant2 = "tenant-2"
         val table1 = "table-1"
         val table2 = "table-2"
-        val createdTableRequestBuilder = CreateTableRequestBuilder.builder()
-                .withAttributeDefinitions(AttributeDefinition(HASH_KEY_FIELD, ScalarAttributeType.S))
-                .withKeySchema(KeySchemaElement(HASH_KEY_FIELD, KeyType.HASH))
-                .withProvisionedThroughput(1L, 1L)
+        val tenant1 = "tenant-1"
+        val tenant2 = "tenant-2"
         val tenantTableMetadataList = ArrayList<MtTableDescriptionRepo.MtCreateTableRequest>()
-        tenantTableMetadataList.add(MtTableDescriptionRepo.MtCreateTableRequest(tenantName = tenant1, createTableRequest = createdTableRequestBuilder.withTableName(table1).build()))
-
+        tenantTableMetadataList.add(getCreateTableRequests(tenant1, table1))
         createOnlyBackupMetadataList("testListBackup", 3, tenantTableMetadataList)
-        tenantTableMetadataList.add(MtTableDescriptionRepo.MtCreateTableRequest(tenantName = tenant2, createTableRequest = createdTableRequestBuilder.withTableName(table2).build()))
+        tenantTableMetadataList.add(getCreateTableRequests(tenant2, table2))
         createOnlyBackupMetadataList("testListBackup-2", 3, tenantTableMetadataList)
         val listBackupResult1: ListBackupsResult = backupManager!!.listTenantTableBackups(ListBackupsRequest().withTableName(table1), tenant1)
         assertEquals(6, listBackupResult1.backupSummaries.size)
         val listBackupResult2: ListBackupsResult = backupManager!!.listTenantTableBackups(ListBackupsRequest().withTableName(table2), tenant2)
         assertEquals(3, listBackupResult2.backupSummaries.size)
     }
+
+    private fun getCreateTableRequests(tenant: String, table: String): MtTableDescriptionRepo.MtCreateTableRequest {
+        val createTableBuilder = CreateTableRequestBuilder.builder()
+                .withAttributeDefinitions(AttributeDefinition(HASH_KEY_FIELD, ScalarAttributeType.S))
+                .withKeySchema(KeySchemaElement(HASH_KEY_FIELD, KeyType.HASH))
+                .withProvisionedThroughput(1L, 1L)
+                .withTableName(table)
+        return MtTableDescriptionRepo.MtCreateTableRequest(
+                tenantName = tenant,
+                createTableRequest = createTableBuilder.build())
+    }
+
+    @Test
+    fun testListTenantBackupsWithBounds() {
+        val clock : Clock = mock(Clock::class.java)
+        val now = System.currentTimeMillis()
+        Mockito.`when`(clock.millis()).thenReturn(now)
+
+        val numBackups = 3
+        val firstBatchIds = createOnlyBackupMetadataList("testListBackups_day_one", numBackups, ImmutableList.of(), clock)
+        Mockito.`when`(clock.millis()).thenReturn(now + TimeUnit.DAYS.toMillis(1))
+        val firstBatch = backupManager!!.listBackups(ListBackupsRequest().withTimeRangeLowerBound(Date(now)))
+        assertEquals(numBackups, firstBatch.backupSummaries.size)
+        assertEquals(firstBatchIds, firstBatch.backupSummaries.stream().map { s -> s.backupName }.collect(Collectors.toList()))
+        val secondBatchIds = createOnlyBackupMetadataList("testListBackups_day_two", 3, ImmutableList.of(), clock)
+        val allBackups = backupManager!!.listBackups(ListBackupsRequest().withTimeRangeLowerBound(Date(now)))
+        assertEquals(numBackups * 2, allBackups.backupSummaries.size)
+        val secondBatch = backupManager!!.listBackups(ListBackupsRequest().withTimeRangeLowerBound(Date(now + 1L)))
+        assertEquals(secondBatchIds, secondBatch.backupSummaries.stream().map { s -> s.backupName }.collect(Collectors.toList()))
+        val firstBatchFiltered = backupManager!!.listBackups(ListBackupsRequest().withTimeRangeUpperBound(Date(now + 1L)))
+        assertEquals(firstBatch, firstBatchFiltered)
+
+        assertTrue(backupManager!!.listBackups(ListBackupsRequest().withTimeRangeLowerBound(Date(now + 1L)).withTimeRangeUpperBound(Date(now + 10L))).backupSummaries.isEmpty())
+    }
+
 
     @Test
     fun testListTenantBackups_empty() {
@@ -286,12 +320,8 @@ internal class MtSharedTableBackupManagerS3It {
     fun testListTenantBackups_pagination() {
         val tenant = "tenant"
         val table = "table"
-        val createdTableRequestBuilder = CreateTableRequestBuilder.builder()
-                .withAttributeDefinitions(AttributeDefinition(HASH_KEY_FIELD, ScalarAttributeType.S))
-                .withKeySchema(KeySchemaElement(HASH_KEY_FIELD, KeyType.HASH))
-                .withProvisionedThroughput(1L, 1L)
         val tenantTableMetadataList = ArrayList<MtTableDescriptionRepo.MtCreateTableRequest>()
-        tenantTableMetadataList.add(MtTableDescriptionRepo.MtCreateTableRequest(tenantName = tenant, createTableRequest = createdTableRequestBuilder.withTableName(table).build()))
+        tenantTableMetadataList.add(getCreateTableRequests(tenant, table))
         val backupIds = createOnlyBackupMetadataList("testListBackups_pagination", 7, ImmutableList.of())
         val expectedBackupIds = createOnlyBackupMetadataList("testListBackups_pagination2-", 7, tenantTableMetadataList)
         backupIds.addAll(expectedBackupIds)
@@ -315,11 +345,12 @@ internal class MtSharedTableBackupManagerS3It {
     /**
      * Create only backup metadata list used to validate list backup tests, and return List of backup IDs created.
      */
-    private fun createOnlyBackupMetadataList(backupPrefix: String, numBackups: Int, tenantTableMetadataList: List<MtTableDescriptionRepo.MtCreateTableRequest> = ImmutableList.of()): ArrayList<String> {
+    private fun createOnlyBackupMetadataList(backupPrefix: String, numBackups: Int, tenantTableMetadataList: List<MtTableDescriptionRepo.MtCreateTableRequest> = ImmutableList.of(),
+                                             clock : Clock = Clock.systemUTC()): ArrayList<String> {
         val ret = Lists.newArrayList<String>()
         backupManager =
                 object : MtSharedTableBackupManager(s3!!, bucket, sharedTableBinaryHashKey!!,
-                        MtBackupTableSnapshotter()) {
+                        MtBackupTableSnapshotter(), clock) {
 
                     // don't actually scan and backup metadata
                     override fun backupVirtualTableMetadata(


### PR DESCRIPTION
In building out a backup process, I want an API to evaluable existing backups to determine if a new backup is necessary. I'm thinking of using a time threshold to take a backup if one does not exist created in the last X hours (ie: 48 or 72). 
At some point, we'll want to delete or remove old backups, but in the meantime, adding a time bound to our listBackups API, so we can ignore backups taken before some period (in the code creating new backups). This time bounds can also be used by a process monitoring for backups that are too old, issuing delete commands. 