### PR TITLE
Pass specific context to TableMappingFactory.getTableMapping

### DIFF
--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/SharedTableBuilder.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/SharedTableBuilder.java
@@ -348,7 +348,6 @@ public class SharedTableBuilder implements TableBuilder {
         if (tableMappingFactory == null) {
             tableMappingFactory = new TableMappingFactory(
                 createTableRequestFactory,
-                mtContext,
                 partitioningStrategy,
                 physicalTableManager
             );

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/TablePartitioningStrategy.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/TablePartitioningStrategy.java
@@ -9,7 +9,6 @@ package com.salesforce.dynamodbv2.mt.mappers.sharedtable;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
-import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
 import com.salesforce.dynamodbv2.mt.mappers.index.DynamoSecondaryIndex;
 import com.salesforce.dynamodbv2.mt.mappers.index.PrimaryKeyMapper;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.DynamoTableDescription;
@@ -49,9 +48,9 @@ public interface TablePartitioningStrategy {
      */
     MtContextAndTable toContextAndTable(ScalarAttributeType physicalHashKeyType, AttributeValue physicalHashKeyValue);
 
-    TableMapping createTableMapping(DynamoTableDescription virtualTable,
+    TableMapping createTableMapping(String context,
+                                    DynamoTableDescription virtualTable,
                                     DynamoTableDescription physicalTable,
-                                    UnaryOperator<DynamoSecondaryIndex> secondaryIndexMapper,
-                                    MtAmazonDynamoDbContextProvider mtContext);
+                                    UnaryOperator<DynamoSecondaryIndex> secondaryIndexMapper);
 
 }

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/AbstractConditionMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/AbstractConditionMapper.java
@@ -47,10 +47,12 @@ import org.antlr.v4.runtime.Recognizer;
 
 abstract class AbstractConditionMapper implements ConditionMapper {
 
+    protected final String context;
     private final DynamoTableDescription virtualTable;
     private final ItemMapper itemMapper;
 
-    AbstractConditionMapper(DynamoTableDescription virtualTable, ItemMapper itemMapper) {
+    AbstractConditionMapper(String context, DynamoTableDescription virtualTable, ItemMapper itemMapper) {
+        this.context = checkNotNull(context);
         this.virtualTable = virtualTable;
         this.itemMapper = itemMapper;
     }

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/AbstractQueryAndScanMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/AbstractQueryAndScanMapper.java
@@ -33,13 +33,16 @@ import java.util.function.Supplier;
 
 abstract class AbstractQueryAndScanMapper implements QueryAndScanMapper {
 
+    protected final String context;
     private final Function<String, RequestIndex> indexLookup;
     private final ConditionMapper conditionMapper;
     private final ItemMapper itemMapper;
 
-    AbstractQueryAndScanMapper(Function<String, RequestIndex> indexLookup,
+    AbstractQueryAndScanMapper(String context,
+                               Function<String, RequestIndex> indexLookup,
                                ConditionMapper conditionMapper,
                                ItemMapper itemMapper) {
+        this.context = checkNotNull(context);
         this.indexLookup = indexLookup;
         this.conditionMapper = conditionMapper;
         this.itemMapper = itemMapper;

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/FieldMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/FieldMapper.java
@@ -5,10 +5,10 @@ import java.util.function.Predicate;
 
 public interface FieldMapper {
 
-    AttributeValue apply(FieldMapping fieldMapping, AttributeValue unqualifiedAttribute);
+    AttributeValue apply(String context, FieldMapping fieldMapping, AttributeValue unqualifiedAttribute);
 
     AttributeValue reverse(FieldMapping fieldMapping, AttributeValue qualifiedAttribute);
 
-    Predicate<AttributeValue> createFilter();
+    Predicate<AttributeValue> createFilter(String context);
 
 }

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningConditionMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningConditionMapper.java
@@ -35,10 +35,11 @@ class HashPartitioningConditionMapper extends AbstractConditionMapper {
     private final HashPartitioningKeyMapper keyMapper;
     private final Multimap<String, String> secondaryIndexFieldPartners;
 
-    HashPartitioningConditionMapper(DynamoTableDescription virtualTable,
+    HashPartitioningConditionMapper(String context,
+                                    DynamoTableDescription virtualTable,
                                     HashPartitioningItemMapper itemMapper,
                                     HashPartitioningKeyMapper keyMapper) {
-        super(virtualTable, itemMapper);
+        super(context, virtualTable, itemMapper);
         this.keyMapper = keyMapper;
         this.secondaryIndexFieldPartners = getSecondaryIndexFieldPartners(virtualTable);
     }

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningKeyMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningKeyMapper.java
@@ -8,6 +8,7 @@
 package com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.HashPartitioningKeyMapper.HashPartitioningKeyBytesConverter.fromStringByteArray;
 import static com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.HashPartitioningKeyMapper.HashPartitioningKeyBytesConverter.toStringByteArray;
@@ -17,7 +18,6 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.UnsignedBytes;
-import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.PrimaryKey;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -58,14 +58,13 @@ public class HashPartitioningKeyMapper {
         }
     }
 
+    private final String context;
     private final String virtualTableName;
-    private final MtAmazonDynamoDbContextProvider mtContext;
     private final int numBucketsPerVirtualTable;
 
-    HashPartitioningKeyMapper(String virtualTableName, MtAmazonDynamoDbContextProvider mtContext,
-                              int numBucketsPerVirtualTable) {
+    HashPartitioningKeyMapper(String context, String virtualTableName, int numBucketsPerVirtualTable) {
+        this.context = checkNotNull(context);
         this.virtualTableName = virtualTableName;
-        this.mtContext = mtContext;
         this.numBucketsPerVirtualTable = numBucketsPerVirtualTable;
     }
 
@@ -75,7 +74,7 @@ public class HashPartitioningKeyMapper {
     }
 
     AttributeValue toPhysicalHashKey(int bucket) {
-        return HashPartitioningKeyPrefixFunction.toPhysicalHashKey(mtContext.getContext(), virtualTableName, bucket);
+        return HashPartitioningKeyPrefixFunction.toPhysicalHashKey(context, virtualTableName, bucket);
     }
 
     int getBucketNumber(ScalarAttributeType virtualHkType, AttributeValue virtualHkValue) {

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningQueryAndScanMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningQueryAndScanMapper.java
@@ -26,12 +26,13 @@ class HashPartitioningQueryAndScanMapper extends AbstractQueryAndScanMapper {
     private final HashPartitioningKeyMapper keyMapper;
     private final int maxBucketNumber;
 
-    HashPartitioningQueryAndScanMapper(DynamoTableDescription physicalTable,
+    HashPartitioningQueryAndScanMapper(String context,
+                                       DynamoTableDescription physicalTable,
                                        Function<String, RequestIndex> indexLookup,
                                        HashPartitioningConditionMapper conditionMapper,
                                        HashPartitioningItemMapper itemMapper,
                                        HashPartitioningKeyMapper keyMapper) {
-        super(indexLookup, conditionMapper, itemMapper);
+        super(context, indexLookup, conditionMapper, itemMapper);
         this.physicalTable = physicalTable;
         this.keyMapper = keyMapper;
         this.maxBucketNumber = keyMapper.getNumberOfBucketsPerVirtualTable() - 1;

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningStrategy.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningStrategy.java
@@ -12,7 +12,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
-import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
 import com.salesforce.dynamodbv2.mt.mappers.index.DynamoSecondaryIndex;
 import com.salesforce.dynamodbv2.mt.mappers.index.PrimaryKeyMapper;
 import com.salesforce.dynamodbv2.mt.mappers.index.PrimaryKeyMapperToBinary;
@@ -69,11 +68,11 @@ public class HashPartitioningStrategy implements TablePartitioningStrategy {
     }
 
     @Override
-    public TableMapping createTableMapping(DynamoTableDescription virtualTable,
+    public TableMapping createTableMapping(String context,
+                                           DynamoTableDescription virtualTable,
                                            DynamoTableDescription physicalTable,
-                                           UnaryOperator<DynamoSecondaryIndex> secondaryIndexMapper,
-                                           MtAmazonDynamoDbContextProvider mtContext) {
-        return new HashPartitioningTableMapping(virtualTable, physicalTable, secondaryIndexMapper, mtContext,
+                                           UnaryOperator<DynamoSecondaryIndex> secondaryIndexMapper) {
+        return new HashPartitioningTableMapping(context, virtualTable, physicalTable, secondaryIndexMapper,
             numBucketsPerVirtualTable);
     }
 }

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtAmazonDynamoDbBySharedTable.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/MtAmazonDynamoDbBySharedTable.java
@@ -423,8 +423,9 @@ public class MtAmazonDynamoDbBySharedTable extends MtAmazonDynamoDbBase {
         try {
             return tableMappingCache.get(virtualTableName, () -> {
                 try {
-
+                    String context = getMtContext().getContext();
                     return Optional.of(tableMappingFactory.getTableMapping(
+                        context,
                         new DynamoTableDescriptionImpl(mtTableDescriptionRepo.getTableDescription(virtualTableName))));
                 } catch (ResourceNotFoundException e) {
                     // This isn't great, but we're assuming a missing virtual table entry here is a deleted virtual

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningConditionMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningConditionMapper.java
@@ -31,8 +31,9 @@ class RandomPartitioningConditionMapper extends AbstractConditionMapper {
     private final RandomPartitioningTableMapping tableMapping;
     private final FieldMapper fieldMapper;
 
-    RandomPartitioningConditionMapper(RandomPartitioningTableMapping tableMapping, FieldMapper fieldMapper) {
-        super(tableMapping.getVirtualTable(), tableMapping.getItemMapper());
+    RandomPartitioningConditionMapper(RandomPartitioningTableMapping tableMapping,
+                                      FieldMapper fieldMapper) {
+        super(tableMapping.getContext(), tableMapping.getVirtualTable(), tableMapping.getItemMapper());
         this.tableMapping = tableMapping;
         this.fieldMapper = fieldMapper;
     }
@@ -69,7 +70,7 @@ class RandomPartitioningConditionMapper extends AbstractConditionMapper {
     }
 
     private AttributeValue applyFieldMapping(FieldMapping fieldMapping, AttributeValue value) {
-        return fieldMapping.isContextAware() ? fieldMapper.apply(fieldMapping, value) : value;
+        return fieldMapping.isContextAware() ? fieldMapper.apply(context, fieldMapping, value) : value;
     }
 
     private String getRangeKeyCondition(ComparisonOperator operator, String fieldPlaceholder,
@@ -140,7 +141,7 @@ class RandomPartitioningConditionMapper extends AbstractConditionMapper {
                     AttributeValue virtualValue = request.getExpressionAttributeValues()
                         .get(valuePlaceholder); // {S: hkValue,}
                     AttributeValue physicalValue = fieldMapping.isContextAware()
-                        ? fieldMapper.apply(fieldMapping, virtualValue) // {S: ctx.virtualTable.hkValue,}
+                        ? fieldMapper.apply(context, fieldMapping, virtualValue) // {S: ctx.virtualTable.hkValue,}
                         : virtualValue;
                     request.putExpressionAttributeValue(valuePlaceholder, physicalValue);
                 }

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningItemMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningItemMapper.java
@@ -8,6 +8,7 @@
 package com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl;
 
 import static com.amazonaws.util.CollectionUtils.isNullOrEmpty;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.salesforce.dynamodbv2.mt.mappers.index.DynamoSecondaryIndex;
@@ -25,16 +26,19 @@ import javax.annotation.Nullable;
  */
 class RandomPartitioningItemMapper implements ItemMapper {
 
+    private final String context;
     private final FieldMapper fieldMapper;
     private final List<FieldMapping> tableVirtualToPhysicalFieldMappings;
     private final Map<DynamoSecondaryIndex, List<FieldMapping>> indexVirtualToPhysicalFieldMappings;
     private final Map<String, List<FieldMapping>> allVirtualToPhysicalFieldMappings;
     private final Map<String, FieldMapping> physicalToVirtualFieldMappings;
 
-    RandomPartitioningItemMapper(FieldMapper fieldMapper,
+    RandomPartitioningItemMapper(String context,
+                                 FieldMapper fieldMapper,
                                  List<FieldMapping> tablePrimaryKeyFieldMappings,
                                  Map<DynamoSecondaryIndex, List<FieldMapping>> indexPrimaryKeyFieldMappings,
                                  Map<String, List<FieldMapping>> allMappingsPerField) {
+        this.context = checkNotNull(context);
         this.fieldMapper = fieldMapper;
         this.tableVirtualToPhysicalFieldMappings = tablePrimaryKeyFieldMappings;
         this.indexVirtualToPhysicalFieldMappings = indexPrimaryKeyFieldMappings;
@@ -99,7 +103,7 @@ class RandomPartitioningItemMapper implements ItemMapper {
      */
     private void applyFieldMapping(Map<String, AttributeValue> item, FieldMapping fieldMapping, AttributeValue value) {
         item.put(fieldMapping.getTarget().getName(),
-            fieldMapping.isContextAware() ? fieldMapper.apply(fieldMapping, value) : value);
+            fieldMapping.isContextAware() ? fieldMapper.apply(context, fieldMapping, value) : value);
     }
 
     @Override

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningQueryAndScanMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningQueryAndScanMapper.java
@@ -38,13 +38,14 @@ class RandomPartitioningQueryAndScanMapper extends AbstractQueryAndScanMapper {
     private final List<FieldMapping> tablePrimaryKeyFieldMappings;
     private final Map<DynamoSecondaryIndex, List<FieldMapping>> indexPrimaryKeyFieldMappings;
 
-    RandomPartitioningQueryAndScanMapper(Function<String, RequestIndex> indexLookup,
+    RandomPartitioningQueryAndScanMapper(String context,
+                                         Function<String, RequestIndex> indexLookup,
                                          ConditionMapper conditionMapper,
                                          ItemMapper itemMapper,
                                          FieldMapper fieldMapper,
                                          List<FieldMapping> tablePrimaryKeyFieldMappings,
                                          Map<DynamoSecondaryIndex, List<FieldMapping>> indexPrimaryKeyFieldMappings) {
-        super(indexLookup, conditionMapper, itemMapper);
+        super(context, indexLookup, conditionMapper, itemMapper);
         this.fieldMapper = fieldMapper;
         this.tablePrimaryKeyFieldMappings = tablePrimaryKeyFieldMappings;
         this.indexPrimaryKeyFieldMappings = indexPrimaryKeyFieldMappings;
@@ -112,7 +113,10 @@ class RandomPartitioningQueryAndScanMapper extends AbstractQueryAndScanMapper {
             fieldMapping.getPhysicalIndexName(),
             fieldMapping.getIndexType(),
             fieldMapping.isContextAware());
-        AttributeValue physicalValuePrefixAttribute = fieldMapper.apply(fieldMappingForPrefix, new AttributeValue(""));
+        AttributeValue physicalValuePrefixAttribute = fieldMapper.apply(
+            context,
+            fieldMappingForPrefix,
+            new AttributeValue(""));
         request.putExpressionAttributeName(NAME_PLACEHOLDER, hashKey.getName());
         request.putExpressionAttributeValue(VALUE_PLACEHOLDER, physicalValuePrefixAttribute);
         request.setExpression(

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningStrategy.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningStrategy.java
@@ -14,7 +14,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
-import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
 import com.salesforce.dynamodbv2.mt.mappers.index.DynamoSecondaryIndex;
 import com.salesforce.dynamodbv2.mt.mappers.index.PrimaryKeyMapper;
 import com.salesforce.dynamodbv2.mt.mappers.index.PrimaryKeyMapperByTypeImpl;
@@ -77,10 +76,10 @@ public class RandomPartitioningStrategy implements TablePartitioningStrategy {
     }
 
     @Override
-    public TableMapping createTableMapping(DynamoTableDescription virtualTable,
+    public TableMapping createTableMapping(String context,
+                                           DynamoTableDescription virtualTable,
                                            DynamoTableDescription physicalTable,
-                                           UnaryOperator<DynamoSecondaryIndex> secondaryIndexMapper,
-                                           MtAmazonDynamoDbContextProvider mtContext) {
-        return new RandomPartitioningTableMapping(virtualTable, physicalTable, secondaryIndexMapper, mtContext);
+                                           UnaryOperator<DynamoSecondaryIndex> secondaryIndexMapper) {
+        return new RandomPartitioningTableMapping(context, virtualTable, physicalTable, secondaryIndexMapper);
     }
 }

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RecordMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RecordMapper.java
@@ -7,10 +7,11 @@
 
 package com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.Record;
 import com.amazonaws.services.dynamodbv2.model.StreamRecord;
-import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
 import com.salesforce.dynamodbv2.mt.mappers.MtAmazonDynamoDb.MtRecord;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -21,18 +22,18 @@ import java.util.function.Predicate;
  */
 public class RecordMapper implements Function<Record, MtRecord> {
 
-    private final MtAmazonDynamoDbContextProvider mtContext;
+    private final String context;
     private final String virtualTableName;
     private final String physicalHashKey;
     private final Predicate<AttributeValue> isMatchingPhysicalHashKey;
     private final ItemMapper itemMapper;
 
-    RecordMapper(MtAmazonDynamoDbContextProvider mtContext,
+    RecordMapper(String context,
                  String virtualTableName,
                  String physicalHashKey,
                  Predicate<AttributeValue> isMatchingPhysicalHashKey,
                  ItemMapper itemMapper) {
-        this.mtContext = mtContext;
+        this.context = checkNotNull(context);
         this.virtualTableName = virtualTableName;
         this.physicalHashKey = physicalHashKey;
         this.isMatchingPhysicalHashKey = isMatchingPhysicalHashKey;
@@ -51,7 +52,8 @@ public class RecordMapper implements Function<Record, MtRecord> {
     @Override
     public MtRecord apply(Record record) {
         final StreamRecord streamRecord = record.getDynamodb();
-        return getDefaultMtRecord(record).withContext(mtContext.getContext())
+        return getDefaultMtRecord(record)
+            .withContext(context)
             .withTableName(virtualTableName)
             .withDynamodb(new StreamRecord()
                 .withKeys(itemMapper.reverse(streamRecord.getKeys())) // should this use key mapper?

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningTestUtil.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningTestUtil.java
@@ -19,7 +19,6 @@ import com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.HashPartitioningKey
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Optional;
 
 class HashPartitioningTestUtil {
 
@@ -46,13 +45,13 @@ class HashPartitioningTestUtil {
     );
 
     static HashPartitioningTableMapping getTableMapping(DynamoTableDescription virtualTable) {
-        return new HashPartitioningTableMapping(virtualTable, PHYSICAL_TABLE,
+        return new HashPartitioningTableMapping(CONTEXT, virtualTable, PHYSICAL_TABLE,
             index -> index.getIndexName().equals(VIRTUAL_GSI) ? PHYSICAL_TABLE.findSi(PHYSICAL_GSI) : null,
-            () -> Optional.of(CONTEXT), NUM_BUCKETS);
+            NUM_BUCKETS);
     }
 
     static HashPartitioningKeyMapper getKeyMapper(DynamoTableDescription virtualTable) {
-        return new HashPartitioningKeyMapper(virtualTable.getTableName(), () -> Optional.of(CONTEXT), NUM_BUCKETS);
+        return new HashPartitioningKeyMapper(CONTEXT, virtualTable.getTableName(), NUM_BUCKETS);
     }
 
     static DynamoTableDescription buildVirtualHkTable(ScalarAttributeType hashKeyType) {

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningItemMapperTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningItemMapperTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
  */
 class RandomPartitioningItemMapperTest {
 
+    private static final String CONTEXT = "context";
     private static final String PREFIX = "PREFIX-";
 
     private static final DynamoTableDescription VIRTUAL_TABLE = TableMappingTestUtil.buildTable("virtualTable",
@@ -36,12 +37,13 @@ class RandomPartitioningItemMapperTest {
         new PrimaryKey("physicalHk", S, "physicalRk", S));
 
     private static final RandomPartitioningTableMapping TABLE_MAPPING = new RandomPartitioningTableMapping(
+        CONTEXT,
         VIRTUAL_TABLE,
         PHYSICAL_TABLE,
-        index -> null,
-        null
+        index -> null
     );
     private static final RandomPartitioningItemMapper SUT = new RandomPartitioningItemMapper(
+        CONTEXT,
         new MockFieldMapper(),
         TABLE_MAPPING.getTablePrimaryKeyFieldMappings(),
         Collections.emptyMap(),
@@ -78,7 +80,7 @@ class RandomPartitioningItemMapperTest {
         }
 
         @Override
-        public AttributeValue apply(FieldMapping fieldMapping, AttributeValue unqualifiedAttribute) {
+        public AttributeValue apply(String context, FieldMapping fieldMapping, AttributeValue unqualifiedAttribute) {
             if (unqualifiedAttribute.getS() != null) {
                 return new AttributeValue().withS(PREFIX + unqualifiedAttribute.getS());
             }
@@ -94,7 +96,7 @@ class RandomPartitioningItemMapperTest {
         }
 
         @Override
-        public Predicate<AttributeValue> createFilter() {
+        public Predicate<AttributeValue> createFilter(String context) {
             return v -> true;
         }
     }

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningQueryAndScanMapperTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningQueryAndScanMapperTest.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.DynamoTableDescription;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.PrimaryKey;
 import java.util.HashMap;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -41,10 +40,10 @@ class RandomPartitioningQueryAndScanMapperTest {
         new PrimaryKey("physicalHk", S),
         ImmutableMap.of("physicalGsi", new PrimaryKey("physicalGsiHk", S)));
     private static final RandomPartitioningTableMapping TABLE_MAPPING = new RandomPartitioningTableMapping(
+        "ctx",
         VIRTUAL_TABLE,
         PHYSICAL_TABLE,
-        index -> PHYSICAL_TABLE.findSi("physicalGsi"),
-        () -> Optional.of("ctx")
+        index -> PHYSICAL_TABLE.findSi("physicalGsi")
     );
     private static final RandomPartitioningQueryAndScanMapper QUERY_AND_SCAN_MAPPER =
         (RandomPartitioningQueryAndScanMapper) TABLE_MAPPING.getQueryAndScanMapper();

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningRecordMapperTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningRecordMapperTest.java
@@ -14,9 +14,7 @@ import com.amazonaws.services.dynamodbv2.model.Record;
 import com.amazonaws.services.dynamodbv2.model.StreamRecord;
 import com.amazonaws.services.dynamodbv2.model.StreamViewType;
 import com.google.common.collect.ImmutableMap;
-import com.salesforce.dynamodbv2.mt.context.MtAmazonDynamoDbContextProvider;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.PrimaryKey;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,16 +23,15 @@ class RandomPartitioningRecordMapperTest {
 
     private final String context = "context";
     private final String tableName = "table";
-    private final MtAmazonDynamoDbContextProvider provider = () -> Optional.of(context);
     private final String virtualHk = "vhk";
     private final String virtualRk = "vrk";
     private final String physicalHk = "phk";
     private final String physicalRk = "prk";
     private final RandomPartitioningTableMapping tableMapping = new RandomPartitioningTableMapping(
+        context,
         buildTable(tableName, new PrimaryKey(virtualHk, S, virtualRk, S)),
         buildTable("physicalTable", new PrimaryKey(physicalHk, S, physicalRk, S)),
-        index -> null,
-        provider
+        index -> null
     );
     private final RecordMapper sut = tableMapping.getRecordMapper();
 

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningTableMappingTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/RandomPartitioningTableMappingTest.java
@@ -40,10 +40,11 @@ class RandomPartitioningTableMappingTest {
     private final DynamoTableDescription physicalTable = TableMappingTestUtil.buildTable("physicalTableName",
         new PrimaryKey("physicalHk", S, "physicalRk", N),
         ImmutableMap.of("physicalGsi", new PrimaryKey("physicalGsiHk", S, "physicalGsiRk", N)));
-    private final RandomPartitioningTableMapping sut = new RandomPartitioningTableMapping(virtualTable,
+    private final RandomPartitioningTableMapping sut = new RandomPartitioningTableMapping(
+        "ctx",
+        virtualTable,
         physicalTable,
-        index -> index.getIndexName().equals("virtualGsi") ? physicalTable.findSi("physicalGsi") : null,
-        null
+        index -> index.getIndexName().equals("virtualGsi") ? physicalTable.findSi("physicalGsi") : null
     );
     private final Map<String, List<FieldMapping>> virtualToPhysicalFieldMappings = ImmutableMap.of(
         "virtualHk", ImmutableList.of(

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/TableMappingFactoryTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/TableMappingFactoryTest.java
@@ -124,7 +124,6 @@ import com.salesforce.dynamodbv2.mt.mappers.sharedtable.TablePartitioningStrateg
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -147,7 +146,7 @@ class TableMappingFactoryTest {
         // should not have called describe again
         reset(dynamoDb);
         final DynamoTableDescription description = new DynamoTableDescriptionImpl(simpleTable("vtable"));
-        sut.getTableMapping(description);
+        sut.getTableMapping("ctx", description);
         verify(dynamoDb, never()).describeTable(any(String.class));
     }
 
@@ -163,12 +162,12 @@ class TableMappingFactoryTest {
 
         // should create table lazily
         final DynamoTableDescription description = new DynamoTableDescriptionImpl(simpleTable("vtable"));
-        sut.getTableMapping(description);
+        sut.getTableMapping("ctx", description);
         assertEquals(TableStatus.ACTIVE.toString(), dynamoDb.describeTable(tableName).getTable().getTableStatus());
 
         // subsequent requests should no longer call describe
         reset(dynamoDb);
-        sut.getTableMapping(description);
+        sut.getTableMapping("ctx", description);
         verify(dynamoDb, never()).describeTable(any(String.class));
     }
 
@@ -185,12 +184,12 @@ class TableMappingFactoryTest {
         // expect that getting a table mapping describes the physical table
         final TableMappingFactory sut = createTestFactory(tableName, false);
         final DynamoTableDescription description = new DynamoTableDescriptionImpl(simpleTable("vtable"));
-        sut.getTableMapping(description);
+        sut.getTableMapping("ctx", description);
         verify(dynamoDb, atLeastOnce()).describeTable(tableName);
 
         // subsequent requests should no longer call describe
         reset(dynamoDb);
-        sut.getTableMapping(description);
+        sut.getTableMapping("ctx", description);
         verify(dynamoDb, never()).describeTable(any(String.class));
     }
 
@@ -209,7 +208,6 @@ class TableMappingFactoryTest {
 
         return new TableMappingFactory(
             new SingletonCreateTableRequestFactory(createTableRequest),
-            Optional::empty,
             strategy,
             physicalTableManager
         );


### PR DESCRIPTION
TableMapping instances are always created and used in the context
of specific tenant and virtual table name. As such, pass
explicit context string to TableMapping constructor (as opposed
to MtAmazonDynamoDbContextProvider) to make the code easier to
comprehend and safer to reuse.

Signed-off-by: Igor Fedorenko <ifedorenko@salesforce.com>