### PR TITLE
support for add when updating items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/antlr4/com/salesforce/dynamodbv2/grammar/Expressions.g4
+++ b/src/main/antlr4/com/salesforce/dynamodbv2/grammar/Expressions.g4
@@ -1,12 +1,18 @@
 grammar Expressions;
 
-// not supported: REMOVE, ADD, DELETE
+// not supported: REMOVE, DELETE
 updateExpression
     : setSection EOF
+    | addSection EOF
+    | setSection addSection EOF
     ;
 
 setSection
     : SET setAction (COMMA setAction)*
+    ;
+
+addSection
+    : ADD addAction (COMMA addAction)*
     ;
 
 // not supported: path = setValue + setValue, path = setValue - setValue
@@ -14,8 +20,16 @@ setAction
     : path '=' setValue
     ;
 
+addAction
+    : path addValue
+    ;
+
 // not supported: non-literal value, if_not_exists, list_append
 setValue
+    : literal
+    ;
+
+addValue
     : literal
     ;
 
@@ -79,6 +93,10 @@ FIELD_PLACEHOLDER
 
 SET
     : [sS][eE][tT]
+    ;
+
+ADD
+    : [aA][dD][dD]
     ;
 
 BETWEEN

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/AbstractConditionMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/AbstractConditionMapper.java
@@ -124,7 +124,7 @@ abstract class AbstractConditionMapper implements ConditionMapper {
         if (updatedField.equals(primaryKey.getHashKey()) || (primaryKey.getRangeKey().isPresent()
             && updatedField.equals(primaryKey.getRangeKey().get()))) {
             throw new IllegalArgumentException(
-                String.format("Cannot update attribute %s. This secondary index is part of the index key",
+                String.format("Cannot update attribute %s with ADD. This secondary index is part of the index key",
                     updatedField));
         }
     }

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/AbstractConditionMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/AbstractConditionMapper.java
@@ -60,22 +60,6 @@ abstract class AbstractConditionMapper implements ConditionMapper {
         this.itemMapper = itemMapper;
     }
 
-    public enum UpdateType {
-        SET("SET"),
-        ADD("ADD");
-
-        private final String value;
-
-        UpdateType(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public String toString() {
-            return this.value;
-        }
-    }
-
     private List<String> getPhysicalUpdateExpressionForAction(RequestWrapper request,
                                                                Map<String, AttributeValue> actions,
                                                                String delimiter) {

--- a/src/test/java/com/salesforce/dynamodbv2/UpdateTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/UpdateTest.java
@@ -240,7 +240,7 @@ class UpdateTest {
             UpdateItemRequest updateItemRequest = new UpdateItemRequest()
                 .withTableName(TABLE1)
                 .withKey(updateItemKey)
-                .withUpdateExpression("add someField :someValue, " + SOME_FIELD + " :someValue")
+                .withUpdateExpression("add " + SOME_FIELD + " :someValue, " + SOME_FIELD + " :someValue")
                 .withExpressionAttributeValues(ImmutableMap.of(":someValue", createNumberAttribute("1")));
             try {
                 testArgument.getAmazonDynamoDb().updateItem(updateItemRequest);

--- a/src/test/java/com/salesforce/dynamodbv2/grammar/ExpressionsTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/grammar/ExpressionsTest.java
@@ -7,6 +7,8 @@
 
 package com.salesforce.dynamodbv2.grammar;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.amazon.dynamodb.grammar.DynamoDbExpressionParser;
 import com.amazon.dynamodb.grammar.DynamoDbGrammarParser;
 import com.amazonaws.services.dynamodbv2.local.shared.env.LocalDBEnv;
@@ -17,6 +19,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -33,7 +36,6 @@ import org.junit.jupiter.params.provider.ValueSource;
  * These tests are helpful for developing request expression grammars / parsing, but don't actually assert anything,
  * and are therefore disabled.
  */
-@Disabled
 class ExpressionsTest {
 
     /*@ParameterizedTest
@@ -62,8 +64,9 @@ class ExpressionsTest {
     @ValueSource(strings = {
         "SET #field1 = :value1",
         "sEt Score = :value1, CreatedBy = :value2",
-        "ADD Score :value2",
+        "add Score :value2",
         "Set Score = :value1 add Score :value2",
+        "set #hkField = :hkValue, #rkField = :rkValue",
 
         "ADD Score :value2, CreatedBy :value1", // add multiple
         "sEt Score = :value1, CreatedBy = :value2 ADD Score :value2", // set multiple, add once
@@ -75,16 +78,49 @@ class ExpressionsTest {
             = new ExpressionsParser(new CommonTokenStream(new ExpressionsLexer(CharStreams.fromString(expression))));
         UpdateExpressionContext context = parser.updateExpression();
 
-        System.out.println("Our tree: " + TreeUtils.toPrettyTree(context, Arrays.asList(ExpressionsParser.ruleNames)));
-
         // dynamodb local grammar
         ANTLRErrorListener listener = new ExpressionErrorListener(new LocalDBEnv());
         ParseTree tree = DynamoDbExpressionParser.parseUpdate(expression, listener);
 
-        System.out.println("Their tree: "
-            + TreeUtils.toPrettyTree(tree, Arrays.asList(DynamoDbGrammarParser.ruleNames)));
+        String dynamodbTree = TreeUtils.toPrettyTree(tree, Arrays.asList(DynamoDbGrammarParser.ruleNames));
+        String ourTree = TreeUtils.toPrettyTree(context, Arrays.asList(ExpressionsParser.ruleNames));
+
+        /*  filter out tree levels that can be ignored
+            - operand is only present in dynamodb tree level before a set value level
+            - update is present in both trees but dynamodb shows update for two levels and
+                our tree shows updateExpression
+            - addValue is only present in our tree to describe the value being added
+         */
+        List<String> dynamodbTreeLevels = Arrays.stream(dynamodbTree.split("\\r?\\n"))
+            .filter(x -> !x.contains("operand") && !x.contains("update"))
+            .collect(Collectors.toList());
+
+        List<String> ourTreeLevels = Arrays.stream(ourTree.split("\\r?\\n"))
+            .filter(x -> !x.contains("operand") && !x.contains("update") && !x.contains("addValue"))
+            .collect(Collectors.toList());
+
+        // assert both trees match
+        int level = 0;
+        for (String ourTreeLevel: ourTreeLevels) {
+            String dynamodbTreeLevel = dynamodbTreeLevels.get(level);
+
+            if (dynamodbTreeLevel.contains("_section") || dynamodbTreeLevel.contains("_action")
+                || dynamodbTreeLevel.contains("_value")) {
+                // dynamodb and our tree contain the same text but differ in the delimiter used and case sensitivity
+                dynamodbTreeLevel.replace("_", "").toLowerCase();
+                ourTreeLevel.toLowerCase();
+            } else if (dynamodbTreeLevel.contains("EOF") || dynamodbTreeLevel.contains("literal")) {
+                // for a SET update value, the dynamodb tree has an `operand` level right before the update value,
+                // causing the additional indentation, for add there is no additional indentation
+                assertEquals(dynamodbTreeLevel.trim(), ourTreeLevel.trim());
+            } else {
+                assertEquals(dynamodbTreeLevels.get(level), "  " + ourTreeLevel);
+            }
+            level++;
+        }
     }
 
+    @Disabled // no assertions present
     @ParameterizedTest
     @ValueSource(strings = {
         "#hk = :hk",
@@ -107,6 +143,7 @@ class ExpressionsTest {
             + TreeUtils.toPrettyTree(tree, Arrays.asList(DynamoDbGrammarParser.ruleNames)));
     }
 
+    @Disabled // no assertions present
     @ParameterizedTest
     @ValueSource(strings = {
         "#hk = :hk",

--- a/src/test/java/com/salesforce/dynamodbv2/grammar/ExpressionsTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/grammar/ExpressionsTest.java
@@ -61,7 +61,13 @@ class ExpressionsTest {
     @ParameterizedTest
     @ValueSource(strings = {
         "SET #field1 = :value1",
-        "sEt Score = :value1, CreatedBy = :value2"
+        "sEt Score = :value1, CreatedBy = :value2",
+        "ADD Score :value2",
+        "Set Score = :value1 add Score :value2",
+
+        "ADD Score :value2, CreatedBy :value1", // add multiple
+        "sEt Score = :value1, CreatedBy = :value2 ADD Score :value2", // set multiple, add once
+        "sEt Score = :value1, CreatedBy = :value2 ADD Score :value2, CreatedBy :value1" // set multiple, add multiple
     })
     void testParseUpdateExpression(String expression) {
         // our grammar

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningConditionMapperTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningConditionMapperTest.java
@@ -35,7 +35,6 @@ import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.UnsignedBytes;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.DynamoTableDescription;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.PrimaryKey;
@@ -46,7 +45,6 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
@@ -86,26 +84,62 @@ class HashPartitioningConditionMapperTest {
         HashPartitioningTableMapping tableMapping = getTableMapping(virtualTable);
         HashPartitioningConditionMapper mapper = tableMapping.getConditionMapper();
 
+        UpdateActions updateActions = new UpdateActions();
+
         // cannot update table primary key fields
-        validateFieldsCanBeUpdatedError(mapper, ImmutableSet.of(VIRTUAL_HK));
-        validateFieldsCanBeUpdatedError(mapper, ImmutableSet.of(VIRTUAL_RK));
-        validateFieldsCanBeUpdatedError(mapper, ImmutableSet.of(VIRTUAL_HK, VIRTUAL_RK));
+        updateActions.setSetActions(ImmutableMap.of(
+            VIRTUAL_HK, new AttributeValue().withS("value")));
+        validateFieldsCanBeUpdatedError(mapper, updateActions);
+
+        updateActions.setSetActions(ImmutableMap.of(
+            VIRTUAL_RK, new AttributeValue().withS("value")));
+        validateFieldsCanBeUpdatedError(mapper, updateActions);
+
+        updateActions.setSetActions(ImmutableMap.of(
+            VIRTUAL_HK, new AttributeValue().withS("value1"),
+            VIRTUAL_RK, new AttributeValue().withS("value2")));
+        validateFieldsCanBeUpdatedError(mapper, updateActions);
 
         // can update a field only if all other index partner fields are updated
-        validateFieldsCanBeUpdatedError(mapper, ImmutableSet.of("A", "B"));
-        validateFieldsCanBeUpdatedError(mapper, ImmutableSet.of("A", "C"));
-        validateFieldsCanBeUpdatedError(mapper, ImmutableSet.of("A", "B", "C"));
+        updateActions.setSetActions(ImmutableMap.of(
+            "A", new AttributeValue().withS("value1"),
+            "B", new AttributeValue().withS("value2")));
+        validateFieldsCanBeUpdatedError(mapper, updateActions);
 
-        // TODO DG - update this test
+        updateActions.setSetActions(ImmutableMap.of(
+            "A", new AttributeValue().withS("value1"),
+            "C", new AttributeValue().withS("value2")));
+        validateFieldsCanBeUpdatedError(mapper, updateActions);
+
+        updateActions.setSetActions(ImmutableMap.of(
+            "A", new AttributeValue().withS("value"),
+            "B", new AttributeValue().withS("value"),
+            "C", new AttributeValue().withS("value")));
+        validateFieldsCanBeUpdatedError(mapper, updateActions);
+
         // valid field combinations
-        // mapper.validateFieldsCanBeUpdated(ImmutableSet.of("A", "B", "C", "D"));
-        // mapper.validateFieldsCanBeUpdated(ImmutableSet.of("E", "F"));
-        // mapper.validateFieldsCanBeUpdated(Collections.emptySet());
+        updateActions.setSetActions(ImmutableMap.of(
+            "A", new AttributeValue().withN("1"),
+            "B", new AttributeValue().withN("2"),
+            "C", new AttributeValue().withN("3"),
+            "D", new AttributeValue().withN("4")));
+        assertEquals(4, updateActions.getSetActions().size());
+        mapper.validateFieldsCanBeUpdated(updateActions);
+
+        updateActions.setSetActions(ImmutableMap.of(
+            "E", new AttributeValue().withN("1"),
+            "F", new AttributeValue().withN("2")));
+        assertEquals(2, updateActions.getSetActions().size());
+        mapper.validateFieldsCanBeUpdated(updateActions);
+
+        updateActions.setSetActions(Collections.emptyMap());
+        assertEquals(Collections.emptyMap(), updateActions.getSetActions());
+        mapper.validateFieldsCanBeUpdated(updateActions);
     }
 
-    private void validateFieldsCanBeUpdatedError(HashPartitioningConditionMapper mapper, Set<String> allSetFields) {
+    private void validateFieldsCanBeUpdatedError(HashPartitioningConditionMapper mapper, UpdateActions allUpdates) {
         try {
-           // mapper.validateFieldsCanBeUpdated(allSetFields);
+            mapper.validateFieldsCanBeUpdated(allUpdates);
             fail("validateFieldsCanBeUpdated() should have thrown exception");
         } catch (AmazonServiceException | IllegalArgumentException e) {
             // expected

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningConditionMapperTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningConditionMapperTest.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.UnsignedBytes;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.DynamoTableDescription;
 import com.salesforce.dynamodbv2.mt.mappers.metadata.PrimaryKey;
+import com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.AbstractConditionMapper.UpdateActions;
 import com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.AbstractQueryAndScanMapper.QueryRequestWrapper;
 import com.salesforce.dynamodbv2.mt.mappers.sharedtable.impl.HashPartitioningTestUtil.TestHashKeyValue;
 import java.nio.ByteBuffer;
@@ -68,7 +69,7 @@ class HashPartitioningConditionMapperTest {
 
         RequestWrapper requestWrapper = new HashPartitioningConditionMapper.UpdateExpressionRequestWrapper(request);
         Map<String, AttributeValue> result = AbstractConditionMapper.parseUpdateExpression(requestWrapper,
-            null).get(0);
+            null).getSetActions();
         assertEquals(ImmutableMap.of(VIRTUAL_GSI_HK, gsiHkValue, VIRTUAL_GSI_RK, gsiRkValue), result);
     }
 
@@ -95,15 +96,16 @@ class HashPartitioningConditionMapperTest {
         validateFieldsCanBeUpdatedError(mapper, ImmutableSet.of("A", "C"));
         validateFieldsCanBeUpdatedError(mapper, ImmutableSet.of("A", "B", "C"));
 
+        // TODO DG - update this test
         // valid field combinations
-        mapper.validateFieldsCanBeUpdated(ImmutableSet.of("A", "B", "C", "D"));
-        mapper.validateFieldsCanBeUpdated(ImmutableSet.of("E", "F"));
-        mapper.validateFieldsCanBeUpdated(Collections.emptySet());
+        // mapper.validateFieldsCanBeUpdated(ImmutableSet.of("A", "B", "C", "D"));
+        // mapper.validateFieldsCanBeUpdated(ImmutableSet.of("E", "F"));
+        // mapper.validateFieldsCanBeUpdated(Collections.emptySet());
     }
 
     private void validateFieldsCanBeUpdatedError(HashPartitioningConditionMapper mapper, Set<String> allSetFields) {
         try {
-            mapper.validateFieldsCanBeUpdated(allSetFields);
+           // mapper.validateFieldsCanBeUpdated(allSetFields);
             fail("validateFieldsCanBeUpdated() should have thrown exception");
         } catch (AmazonServiceException | IllegalArgumentException e) {
             // expected

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningConditionMapperTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningConditionMapperTest.java
@@ -68,7 +68,7 @@ class HashPartitioningConditionMapperTest {
 
         RequestWrapper requestWrapper = new HashPartitioningConditionMapper.UpdateExpressionRequestWrapper(request);
         Map<String, AttributeValue> result = AbstractConditionMapper.parseUpdateExpression(requestWrapper,
-            null);
+            null).getFirst();
         assertEquals(ImmutableMap.of(VIRTUAL_GSI_HK, gsiHkValue, VIRTUAL_GSI_RK, gsiRkValue), result);
     }
 

--- a/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningConditionMapperTest.java
+++ b/src/test/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningConditionMapperTest.java
@@ -68,7 +68,7 @@ class HashPartitioningConditionMapperTest {
 
         RequestWrapper requestWrapper = new HashPartitioningConditionMapper.UpdateExpressionRequestWrapper(request);
         Map<String, AttributeValue> result = AbstractConditionMapper.parseUpdateExpression(requestWrapper,
-            null).getFirst();
+            null).get(0);
         assertEquals(ImmutableMap.of(VIRTUAL_GSI_HK, gsiHkValue, VIRTUAL_GSI_RK, gsiRkValue), result);
     }
 

--- a/src/test/java/com/salesforce/dynamodbv2/testsupport/ItemBuilder.java
+++ b/src/test/java/com/salesforce/dynamodbv2/testsupport/ItemBuilder.java
@@ -17,6 +17,8 @@ public class ItemBuilder {
     public static final String HASH_KEY_FIELD = "hashKeyField";
     public static final String RANGE_KEY_FIELD = "rangeKeyField";
     public static final String SOME_FIELD = "someField";
+    public static final String SOME_OTHER_FIELD = "someOtherField";
+    public static final String SOME_OTHER_OTHER_FIELD = "someOtherOtherField";
     public static final String INDEX_FIELD = "indexField";
     public static final String GSI_HK_FIELD = "gsiHkField";
     public static final String GSI2_HK_FIELD = "gsi2HkField";
@@ -52,6 +54,16 @@ public class ItemBuilder {
 
     public ItemBuilder someField(ScalarAttributeType type, String someFieldValue) {
         this.item.put(SOME_FIELD, createAttributeValue(type, someFieldValue));
+        return this;
+    }
+
+    public ItemBuilder someOtherField(ScalarAttributeType type, String someOtherFieldValue) {
+        this.item.put(SOME_OTHER_FIELD, createAttributeValue(type, someOtherFieldValue));
+        return this;
+    }
+
+    public ItemBuilder someOtherOtherField(ScalarAttributeType type, String someOtherOtherFieldValue) {
+        this.item.put(SOME_OTHER_OTHER_FIELD, createAttributeValue(type, someOtherOtherFieldValue));
         return this;
     }
 

--- a/src/test/java/com/salesforce/dynamodbv2/testsupport/TestSupport.java
+++ b/src/test/java/com/salesforce/dynamodbv2/testsupport/TestSupport.java
@@ -1,5 +1,6 @@
 package com.salesforce.dynamodbv2.testsupport;
 
+import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.N;
 import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
 import static com.salesforce.dynamodbv2.testsupport.ItemBuilder.HASH_KEY_FIELD;
 import static com.salesforce.dynamodbv2.testsupport.ItemBuilder.RANGE_KEY_FIELD;
@@ -148,6 +149,10 @@ public class TestSupport {
 
     public static AttributeValue createStringAttribute(String value) {
         return createAttributeValue(S, value);
+    }
+
+    public static AttributeValue createNumberAttribute(String value) {
+        return createAttributeValue(N, value);
     }
 
     /**


### PR DESCRIPTION
Supports ADD action type in UpdateItemExpression's in addition to existing support for SET.  Restricts ADD support for HashPartitioningConditionMapper if the index field is part of the index key.