### PR TITLE
Fix delta race

### DIFF
--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningKeyMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningKeyMapper.java
@@ -48,8 +48,13 @@ public class HashPartitioningKeyMapper {
             return new AttributeValue().withB(byteBuffer);
         }
 
+<<<<<<< Updated upstream
         public static MtContextAndTable fromPhysicalHashKey(AttributeValue value) {
             ByteBuffer byteBuffer = value.getB().rewind();
+=======
+        static MtContextAndTable fromPhysicalHashKey(AttributeValue value) {
+            ByteBuffer byteBuffer = value.getB().duplicate().rewind();
+>>>>>>> Stashed changes
             byte[] contextBytes = new byte[byteBuffer.getShort()];
             byteBuffer.get(contextBytes);
             byte[] tableNameBytes = new byte[byteBuffer.getShort()];

--- a/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningKeyMapper.java
+++ b/src/main/java/com/salesforce/dynamodbv2/mt/mappers/sharedtable/impl/HashPartitioningKeyMapper.java
@@ -48,13 +48,8 @@ public class HashPartitioningKeyMapper {
             return new AttributeValue().withB(byteBuffer);
         }
 
-<<<<<<< Updated upstream
         public static MtContextAndTable fromPhysicalHashKey(AttributeValue value) {
-            ByteBuffer byteBuffer = value.getB().rewind();
-=======
-        static MtContextAndTable fromPhysicalHashKey(AttributeValue value) {
             ByteBuffer byteBuffer = value.getB().duplicate().rewind();
->>>>>>> Stashed changes
             byte[] contextBytes = new byte[byteBuffer.getShort()];
             byteBuffer.get(contextBytes);
             byte[] tableNameBytes = new byte[byteBuffer.getShort()];


### PR DESCRIPTION
this doesn't fix the deeper issue of caching these rows on dynamo, and different threads potentially modifying buffers on each other, but it does fix the primary key conversion to be immune to this race condition present on the streams cache. 